### PR TITLE
Add installation instructions for conda-forge package

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
   - [Installing and Using the Tool](#installing-and-using-the-tool)
     - [Option 1: Download Pre-built Binary](#option-1-download-pre-built-binary)
     - [Option 2: Install via Cargo](#option-2-install-via-cargo)
-    - [Option 3: Build from Source](#option-3-build-from-source)
+    - [Option 3: Install via Conda, Mamba, or Pixi](#option-3-install-via-conda-mamba-or-pixi)
+    - [Option 4: Build from Source](#option-4-build-from-source)
   - [Usage](#usage)
   - [Key Bindings](#key-bindings)
   - [View Modes](#view-modes)
@@ -188,7 +189,34 @@ If you have Rust and Cargo installed on your system, you can easily install NviW
 
 Note: Ensure you have the NVIDIA Management Library (NVML) available on your system before running NviWatch.
 
-### Option 3: Build from Source
+### Option 3: Install via Conda, Mamba, or Pixi
+
+NviWatch is also available from conda-forge for conda-based environments.
+
+1. With Conda:
+   ```bash
+   # After activating an environment
+   conda install -c conda-forge nviwatch
+   ```
+
+2. With Mamba:
+   ```bash
+   # After activating an environment
+   mamba install -c conda-forge nviwatch
+   ```
+
+3. With Pixi:
+   ```bash
+   # Install nviwatch user-globally, not into a specific environment 
+   pixi global install --channel conda-forge nviwatch
+   ```
+
+4. Once installed, you can run NviWatch with:
+   ```bash
+   nviwatch
+   ```
+
+### Option 4: Build from Source
 
 To build and run NviWatch, ensure you have Rust and Cargo installed on your system. You will also need the NVIDIA Management Library (NVML) available.
 


### PR DESCRIPTION
Hi,

I have added nviwatch to conda-forge, so users can now install it via from the conda-forge channel. This PR updates the documentation to include installation methods using `conda`, `mamba`, and `pixi`.

* Added a new installation option in the documentation for installing NviWatch via Conda, Mamba, or Pixi, including step-by-step commands for each method and instructions for running the tool after installation.

* Updated the table of contents to reflect the addition of the new conda-based installation option and renumbered the build-from-source instructions accordingly.