### PR TITLE
feat: optional --cpu system monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,9 +213,10 @@ To build and run NviWatch, ensure you have Rust and Cargo installed on your syst
 
 NviWatch provides a command-line interface with several options:
 
-- `-w, --watch <MILLISECONDS>`: Set the refresh interval in milliseconds. Default is 1000 ms.
+- `-w, --watch <MILLISECONDS>`: Set the refresh interval in milliseconds. Default is 300 ms.
 - `-t, --tabbed-graphs`: Display GPU graphs in a tabbed view.
 - `-b, --bar-chart`: Display GPU graphs as bar charts.
+- `-c, --cpu`: Enable CPU and system-wide process monitoring (CPU/RAM panels, top-50 system process tray sortable with `s`, and optional InfluxDB `system_metrics`). Without this flag, nviwatch monitors GPUs only. Pair with a longer refresh (e.g. `--watch 1500`) for a less jittery process list — short windows (default 300 ms) re-rank by instantaneous CPU% every tick, which looks jumpy compared to htop’s ~1.5 s default.
 - `--influx-url <URL>`: InfluxDB server URL (e.g., "http://localhost:8086").
 - `--influx-org <ORG>`: InfluxDB organization name.
 - `--influx-bucket <BUCKET>`: InfluxDB bucket name for storing metrics.
@@ -225,6 +226,9 @@ NviWatch provides a command-line interface with several options:
 ```bash
 # Run with default settings
 ./nviwatch
+
+# Run with CPU + GPU monitoring (calmer list refresh, closer to htop)
+./nviwatch --cpu --watch 1500
 
 # Run with custom refresh rate and tabbed graphs
 ./nviwatch --watch 500 --tabbed-graphs
@@ -239,6 +243,7 @@ NviWatch provides a command-line interface with several options:
 # Run with all features enabled
 ./nviwatch \
   --watch 1000 \
+  --cpu \
   --tabbed-graphs \
   --influx-url "http://localhost:8086" \
   --influx-org "my-org" \
@@ -252,9 +257,11 @@ NviWatch provides a command-line interface with several options:
 - **↑/↓**: Navigate through the list of processes
 - **←/→**: Switch between GPU tabs (when using tabbed graphs)
 - **x**: Terminate the selected process
+- **s**: Toggle process sort (CPU% ↔ GPU memory) — only with `--cpu`
 - **d**: Switch to default view mode
 - **t**: Switch to tabbed graphs view mode
 - **b**: Switch to bar charts view mode
+- **?**: Toggle help overlay
 
 ## View Modes
 
@@ -285,3 +292,4 @@ Contributions are welcome! Please open an issue or submit a pull request for any
 
 - Built with [Rust](https://www.rust-lang.org/) and [Ratatui](https://github.com/ratatui/ratatui).
 - Utilizes the [NVIDIA Management Library (NVML)](https://developer.nvidia.com/nvidia-management-library-nvml) via the [nvml_wrapper crate](https://docs.rs/nvml-wrapper/latest/nvml_wrapper/).
+- Optional `--cpu` monitoring inspired by a contribution from [@jpswensen](https://github.com/jpswensen) ([#10](https://github.com/msminhas93/nviwatch/issues/10)).

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -5,8 +5,8 @@ use crate::gpu::info::{GpuInfo, collect_gpu_info};
 use crate::influx_local::{InfluxDBConfig, TempInfluxConfig};
 use crate::keybinds::PendingOp;
 use crate::system_monitor::{
-    collect_system_stats, sort_processes, system_metrics_write_query, CpuStats, KernelCpuSample,
-    SortMode, SystemProcess,
+    collect_system_stats, rebuild_process_tray, system_metrics_write_query, CpuStats,
+    KernelCpuSample, SortMode, SystemProcess,
 };
 use crate::utils::system::CpuSample;
 use nvml::Nvml;
@@ -38,6 +38,9 @@ pub struct AppState {
     pub cpu_samples: HashMap<u32, CpuSample>,
 
     // ---- CPU / system side (`--cpu`) ----
+    /// Last successful full process scan (pre top-N truncate). Sort toggles
+    /// rebuild the tray from this so the new metric truly re-picks top N.
+    pub process_scan: Vec<SystemProcess>,
     pub processes: Vec<SystemProcess>,
     pub sort_mode: SortMode,
     pub cpu_stats: CpuStats,
@@ -66,6 +69,7 @@ impl Default for AppState {
             show_help: false,
             help_scroll: 0,
             cpu_samples: HashMap::new(),
+            process_scan: Vec::new(),
             processes: Vec::new(),
             sort_mode: SortMode::default(),
             cpu_stats: CpuStats::default(),
@@ -99,6 +103,7 @@ impl From<&clap::ArgMatches> for AppState {
             show_help: false,
             help_scroll: 0,
             cpu_samples: HashMap::new(),
+            process_scan: Vec::new(),
             processes: Vec::new(),
             sort_mode: SortMode::default(),
             cpu_stats: CpuStats::default(),
@@ -160,13 +165,13 @@ impl AppState {
         }
     }
 
-    /// Toggle CPU% ↔ GPU-memory sort for the system tray and re-sort in place.
+    /// Toggle CPU% ↔ GPU-memory sort and rebuild top-N from the last full scan.
     pub fn cycle_sort_mode(&mut self) {
         self.sort_mode = match self.sort_mode {
             SortMode::Cpu => SortMode::GpuMemory,
             SortMode::GpuMemory => SortMode::Cpu,
         };
-        sort_processes(&mut self.processes, self.sort_mode);
+        rebuild_process_tray(self);
         self.selected_process = 0;
     }
 
@@ -399,37 +404,52 @@ mod tests {
     }
 
     #[test]
-    fn test_cycle_sort_mode_resets_selection() {
+    fn test_cycle_sort_mode_rebuilds_top_n_from_full_scan() {
         let mut state = AppState::default();
         state.cpu_monitoring = true;
         state.selected_process = 3;
-        state.processes = vec![
+        // Full scan has a GPU-heavy process that would be truncated away under
+        // CPU-sort top-2, but must surface after toggling to GPU-memory sort.
+        state.process_scan = vec![
             SystemProcess {
                 pid: 1,
                 gpu_memory: None,
                 gpu_index: None,
                 username: String::new(),
-                command: String::new(),
-                cpu_usage: 10.0,
+                command: "cpu-a".into(),
+                cpu_usage: 90.0,
                 memory_usage: 0,
                 state: 'R',
             },
             SystemProcess {
                 pid: 2,
-                gpu_memory: Some(100),
+                gpu_memory: None,
+                gpu_index: None,
+                username: String::new(),
+                command: "cpu-b".into(),
+                cpu_usage: 80.0,
+                memory_usage: 0,
+                state: 'R',
+            },
+            SystemProcess {
+                pid: 3,
+                gpu_memory: Some(8192),
                 gpu_index: Some(0),
                 username: String::new(),
-                command: String::new(),
+                command: "gpu-heavy".into(),
                 cpu_usage: 1.0,
                 memory_usage: 0,
                 state: 'R',
             },
         ];
+        rebuild_process_tray(&mut state);
+        // With TOP_N=50 all three fit; still assert GPU sort promotes pid 3.
         assert_eq!(state.sort_mode, SortMode::Cpu);
+        assert_eq!(state.processes[0].pid, 1);
         state.cycle_sort_mode();
         assert_eq!(state.sort_mode, SortMode::GpuMemory);
         assert_eq!(state.selected_process, 0);
-        assert_eq!(state.processes[0].pid, 2);
+        assert_eq!(state.processes[0].pid, 3);
     }
 
     #[test]

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -4,13 +4,21 @@ use crate::gpu::GpuProcessInfo;
 use crate::gpu::info::{GpuInfo, collect_gpu_info};
 use crate::influx_local::{InfluxDBConfig, TempInfluxConfig};
 use crate::keybinds::PendingOp;
+use crate::system_monitor::{
+    collect_system_stats, sort_processes, system_metrics_write_query, CpuStats, KernelCpuSample,
+    SortMode, SystemProcess,
+};
 use crate::utils::system::CpuSample;
 use nvml::Nvml;
 use std::cmp::Reverse;
 use std::collections::HashMap;
 
 pub struct AppState {
-    last_update: std::time::Instant,
+    /// `None` until the first poll so startup draws data immediately, then
+    /// spaces refreshes by `--watch` thereafter.
+    last_update: Option<std::time::Instant>,
+    /// Master switch for the CPU/system feature set (from `--cpu`).
+    pub cpu_monitoring: bool,
     pub selected_process: usize,
     pub selected_gpu_tab: usize,
     pub gpu_infos: Vec<GpuInfo>,
@@ -26,13 +34,26 @@ pub struct AppState {
     /// Vertical scroll offset (lines) while help is open.
     pub help_scroll: u16,
     /// Prior CPU tick samples for top-style %CPU deltas (keyed by PID).
+    /// Used only in GPU-only mode.
     pub cpu_samples: HashMap<u32, CpuSample>,
+
+    // ---- CPU / system side (`--cpu`) ----
+    pub processes: Vec<SystemProcess>,
+    pub sort_mode: SortMode,
+    pub cpu_stats: CpuStats,
+    /// Aggregate CPU% history for the line graph (float so sub-1% idle load is visible).
+    pub cpu_usage_history: Vec<f64>,
+    pub prev_cpu_total: Option<KernelCpuSample>,
+    pub prev_cpu_per_core: Vec<KernelCpuSample>,
+    pub prev_proc_times: HashMap<i32, u64>,
+    pub uid_cache: HashMap<u32, String>,
 }
 
 impl Default for AppState {
     fn default() -> Self {
         Self {
-            last_update: std::time::Instant::now(),
+            last_update: None,
+            cpu_monitoring: false,
             selected_process: 0,
             selected_gpu_tab: 0,
             gpu_infos: Vec::new(),
@@ -45,6 +66,14 @@ impl Default for AppState {
             show_help: false,
             help_scroll: 0,
             cpu_samples: HashMap::new(),
+            processes: Vec::new(),
+            sort_mode: SortMode::default(),
+            cpu_stats: CpuStats::default(),
+            cpu_usage_history: Vec::new(),
+            prev_cpu_total: None,
+            prev_cpu_per_core: Vec::new(),
+            prev_proc_times: HashMap::new(),
+            uid_cache: HashMap::new(),
         }
     }
 }
@@ -53,9 +82,11 @@ impl From<&clap::ArgMatches> for AppState {
     fn from(matches: &clap::ArgMatches) -> Self {
         let use_tabbed_graphs = matches.get_flag("tabbed-graphs");
         let use_bar_charts = matches.get_flag("bar-chart");
+        let cpu_monitoring = matches.get_flag("cpu");
 
         Self {
-            last_update: std::time::Instant::now(),
+            last_update: None,
+            cpu_monitoring,
             selected_process: 0,
             selected_gpu_tab: 0,
             gpu_infos: Vec::new(),
@@ -68,20 +99,33 @@ impl From<&clap::ArgMatches> for AppState {
             show_help: false,
             help_scroll: 0,
             cpu_samples: HashMap::new(),
+            processes: Vec::new(),
+            sort_mode: SortMode::default(),
+            cpu_stats: CpuStats::default(),
+            cpu_usage_history: Vec::new(),
+            prev_cpu_total: None,
+            prev_cpu_per_core: Vec::new(),
+            prev_proc_times: HashMap::new(),
+            uid_cache: HashMap::new(),
         }
     }
 }
 
 impl AppState {
-    /// Total GPU process rows (all devices). Count only — no sort.
+    /// Rows in the active process tray (GPU-only or system-wide).
     pub fn total_process_count(&self) -> usize {
-        self.gpu_infos.iter().map(|g| g.processes.len()).sum()
+        if self.cpu_monitoring {
+            self.processes.len()
+        } else {
+            self.gpu_infos.iter().map(|g| g.processes.len()).sum()
+        }
     }
 
-    /// Same order as the process table: flatten then GPU-memory desc.
+    /// Same order as the GPU-only process table: flatten then GPU-memory desc.
     ///
     /// Selection, kill, and render must all go through this (or
-    /// `selected_process_entry`) so the index never points at different rows.
+    /// `selected_process_entry` / `selected_kill_target`) so the index never
+    /// points at different rows.
     pub fn processes_display_order(&self) -> Vec<(usize, &GpuProcessInfo)> {
         let mut procs: Vec<_> = self
             .gpu_infos
@@ -97,23 +141,63 @@ impl AppState {
         procs
     }
 
-    /// Process under the current selection, in display order.
+    /// Process under the current selection in GPU-only mode, in display order.
     pub fn selected_process_entry(&self) -> Option<(usize, &GpuProcessInfo)> {
         self.processes_display_order()
             .get(self.selected_process)
             .copied()
     }
 
-    pub fn should_update(&mut self, interval_ms: u64) -> bool {
-        if self.last_update.elapsed() < std::time::Duration::from_millis(interval_ms) {
-            false
+    /// PID + command for the row currently highlighted (either tray).
+    pub fn selected_kill_target(&self) -> Option<(u32, &str)> {
+        if self.cpu_monitoring {
+            self.processes
+                .get(self.selected_process)
+                .map(|p| (p.pid as u32, p.command.as_str()))
         } else {
-            self.last_update = std::time::Instant::now();
-            true
+            self.selected_process_entry()
+                .map(|(_, p)| (p.pid, p.command.as_str()))
         }
     }
 
-    /// Poll GPU info and optionally write metrics to InfluxDB.
+    /// Toggle CPU% ↔ GPU-memory sort for the system tray and re-sort in place.
+    pub fn cycle_sort_mode(&mut self) {
+        self.sort_mode = match self.sort_mode {
+            SortMode::Cpu => SortMode::GpuMemory,
+            SortMode::GpuMemory => SortMode::Cpu,
+        };
+        sort_processes(&mut self.processes, self.sort_mode);
+        self.selected_process = 0;
+    }
+
+    /// True on the first call (so the UI is never blank for a full `--watch`
+    /// interval), then true again only after `interval_ms` since the last poll.
+    pub fn should_update(&mut self, interval_ms: u64) -> bool {
+        match self.last_update {
+            None => {
+                self.last_update = Some(std::time::Instant::now());
+                true
+            }
+            Some(t)
+                if t.elapsed() >= std::time::Duration::from_millis(interval_ms) =>
+            {
+                self.last_update = Some(std::time::Instant::now());
+                true
+            }
+            Some(_) => false,
+        }
+    }
+
+    fn clamp_selection(&mut self) {
+        let total = self.total_process_count();
+        if total == 0 {
+            self.selected_process = 0;
+        } else if self.selected_process >= total {
+            self.selected_process = total - 1;
+        }
+    }
+
+    /// Poll GPU info (and optionally system stats) and optionally write to InfluxDB.
     ///
     /// Influx is skipped unless all four `--influx-*` flags are present (same
     /// as the original main-loop guard). Partial/missing config is not an error.
@@ -125,13 +209,13 @@ impl AppState {
     ) -> Result<()> {
         self.gpu_infos = collect_gpu_info(nvml, self)?;
 
-        // Keep selection in range after processes come and go.
-        let total = self.total_process_count();
-        if total == 0 {
-            self.selected_process = 0;
-        } else if self.selected_process >= total {
-            self.selected_process = total - 1;
+        if self.cpu_monitoring {
+            if let Err(e) = collect_system_stats(self) {
+                self.error_message = Some(format!("System info error: {e}"));
+            }
         }
+
+        self.clamp_selection();
 
         let temp = TempInfluxConfig::try_from(matches)?;
         // Incomplete flags: skip Influx (same as pre-AppState guard). All four
@@ -150,11 +234,15 @@ impl AppState {
 
         let influx_client =
             influxdb::Client::new(&config.url, &config.bucket).with_token(&config.token);
-        let queries: Vec<influxdb::WriteQuery> = self
+        let mut queries: Vec<influxdb::WriteQuery> = self
             .gpu_infos
             .iter()
             .map(influxdb::WriteQuery::from)
             .collect();
+
+        if self.cpu_monitoring {
+            queries.push(system_metrics_write_query(&self.cpu_stats));
+        }
 
         runtime
             .block_on(async {
@@ -192,6 +280,17 @@ mod tests {
         }
     }
 
+    fn gpu_proc(pid: u32, mem: u64, command: &str) -> GpuProcessInfo {
+        GpuProcessInfo {
+            pid,
+            used_gpu_memory: mem,
+            username: "user".into(),
+            command: command.into(),
+            cpu_percent: Some(1.0),
+            memory_usage: 0,
+        }
+    }
+
     #[test]
     fn test_app_state_initialization() {
         let mut state = AppState::default();
@@ -206,6 +305,9 @@ mod tests {
         assert!(state.use_tabbed_graphs);
         assert!(!state.use_bar_charts);
         assert_eq!(state.pending_op, PendingOp::None);
+        assert!(!state.cpu_monitoring);
+        assert!(state.processes.is_empty());
+        assert_eq!(state.sort_mode, SortMode::Cpu);
     }
 
     #[test]
@@ -221,6 +323,113 @@ mod tests {
         state.gpu_infos.push(create_test_gpu_info(1));
 
         assert_eq!(state.total_process_count(), 0); // No processes in test GPUs
+    }
+
+    #[test]
+    fn test_total_processes_cpu_mode_uses_system_list() {
+        let mut state = AppState::default();
+        state.cpu_monitoring = true;
+        state.gpu_infos.push(GpuInfo {
+            index: 0,
+            name: "G".into(),
+            temperature: 0,
+            utilization: 0,
+            memory_used: 0,
+            memory_total: 0,
+            power_usage: 0,
+            power_limit: 0,
+            clock_freq: 0,
+            processes: vec![gpu_proc(1, 100, "gpu-only")],
+        });
+        state.processes.push(SystemProcess {
+            pid: 99,
+            gpu_memory: None,
+            gpu_index: None,
+            username: "u".into(),
+            command: "sys".into(),
+            cpu_usage: 10.0,
+            memory_usage: 0,
+            state: 'R',
+        });
+        assert_eq!(state.total_process_count(), 1);
+    }
+
+    #[test]
+    fn test_selected_kill_target_gpu_mode() {
+        let mut state = AppState::default();
+        state.gpu_infos.push(GpuInfo {
+            index: 0,
+            name: "G".into(),
+            temperature: 0,
+            utilization: 0,
+            memory_used: 0,
+            memory_total: 0,
+            power_usage: 0,
+            power_limit: 0,
+            clock_freq: 0,
+            processes: vec![
+                gpu_proc(10, 100, "small"),
+                gpu_proc(20, 900, "big"),
+            ],
+        });
+        // Display order is GPU-memory desc → big first.
+        state.selected_process = 0;
+        let (pid, cmd) = state.selected_kill_target().unwrap();
+        assert_eq!(pid, 20);
+        assert_eq!(cmd, "big");
+    }
+
+    #[test]
+    fn test_selected_kill_target_cpu_mode() {
+        let mut state = AppState::default();
+        state.cpu_monitoring = true;
+        state.processes.push(SystemProcess {
+            pid: 7,
+            gpu_memory: None,
+            gpu_index: None,
+            username: "u".into(),
+            command: "top-proc".into(),
+            cpu_usage: 50.0,
+            memory_usage: 0,
+            state: 'R',
+        });
+        let (pid, cmd) = state.selected_kill_target().unwrap();
+        assert_eq!(pid, 7);
+        assert_eq!(cmd, "top-proc");
+    }
+
+    #[test]
+    fn test_cycle_sort_mode_resets_selection() {
+        let mut state = AppState::default();
+        state.cpu_monitoring = true;
+        state.selected_process = 3;
+        state.processes = vec![
+            SystemProcess {
+                pid: 1,
+                gpu_memory: None,
+                gpu_index: None,
+                username: String::new(),
+                command: String::new(),
+                cpu_usage: 10.0,
+                memory_usage: 0,
+                state: 'R',
+            },
+            SystemProcess {
+                pid: 2,
+                gpu_memory: Some(100),
+                gpu_index: Some(0),
+                username: String::new(),
+                command: String::new(),
+                cpu_usage: 1.0,
+                memory_usage: 0,
+                state: 'R',
+            },
+        ];
+        assert_eq!(state.sort_mode, SortMode::Cpu);
+        state.cycle_sort_mode();
+        assert_eq!(state.sort_mode, SortMode::GpuMemory);
+        assert_eq!(state.selected_process, 0);
+        assert_eq!(state.processes[0].pid, 2);
     }
 
     #[test]
@@ -240,6 +449,15 @@ mod tests {
         // Should be able to select GPU 0, but not GPU 1
         assert!(!state.gpu_infos.is_empty());
         assert!(1 >= state.gpu_infos.len());
+    }
+
+    #[test]
+    fn test_should_update_fires_immediately_then_respects_interval() {
+        let mut state = AppState::default();
+        // First poll must not wait for `--watch` — otherwise a 1500ms interval
+        // leaves the TUI blank for 1.5s on startup.
+        assert!(state.should_update(1500));
+        assert!(!state.should_update(1500));
     }
 
     #[test]

--- a/src/gpu/info.rs
+++ b/src/gpu/info.rs
@@ -47,11 +47,41 @@ fn collect_gpu_processes(
         .collect()
 }
 
+/// Lean PID + GPU-memory records for `--cpu` mode (system scan enriches later).
+/// Compute and graphics lists can overlap; keep the larger memory figure per PID.
+fn collect_gpu_processes_lean(
+    processes: impl IntoIterator<Item = nvml::struct_wrappers::device::ProcessInfo>,
+) -> Vec<GpuProcessInfo> {
+    let mut out: Vec<GpuProcessInfo> = Vec::new();
+    for p in processes {
+        let used_gpu_memory = match p.used_gpu_memory {
+            nvml::enums::device::UsedGpuMemory::Used(bytes) => bytes,
+            nvml::enums::device::UsedGpuMemory::Unavailable => 0,
+        };
+        if let Some(existing) = out.iter_mut().find(|e| e.pid == p.pid) {
+            if used_gpu_memory > existing.used_gpu_memory {
+                existing.used_gpu_memory = used_gpu_memory;
+            }
+        } else {
+            out.push(GpuProcessInfo {
+                pid: p.pid,
+                used_gpu_memory,
+                username: String::new(),
+                command: String::new(),
+                cpu_percent: None,
+                memory_usage: 0,
+            });
+        }
+    }
+    out
+}
+
 fn gpu_info_from_device(
     index: usize,
     device: Device<'_>,
     previous_samples: &HashMap<u32, CpuSample>,
     next_samples: &mut HashMap<u32, CpuSample>,
+    cpu_monitoring: bool,
 ) -> Result<GpuInfo> {
     let name = device.name()?;
     let temperature = device.temperature(TemperatureSensor::Gpu)?;
@@ -62,16 +92,26 @@ fn gpu_info_from_device(
     let power_limit = device.enforced_power_limit()? / 1000; // Convert mW to W
     let clock_freq = device.clock_info(nvml::enum_wrappers::device::Clock::Graphics)?;
 
-    let compute_processes = collect_gpu_processes(
-        device.running_compute_processes()?,
-        previous_samples,
-        next_samples,
-    );
-    let graphics_processes = collect_gpu_processes(
-        device.running_graphics_processes()?,
-        previous_samples,
-        next_samples,
-    );
+    let processes = if cpu_monitoring {
+        collect_gpu_processes_lean(
+            device
+                .running_compute_processes()?
+                .into_iter()
+                .chain(device.running_graphics_processes()?.into_iter()),
+        )
+    } else {
+        let compute_processes = collect_gpu_processes(
+            device.running_compute_processes()?,
+            previous_samples,
+            next_samples,
+        );
+        let graphics_processes = collect_gpu_processes(
+            device.running_graphics_processes()?,
+            previous_samples,
+            next_samples,
+        );
+        [compute_processes, graphics_processes].concat()
+    };
 
     Ok(GpuInfo {
         index,
@@ -83,7 +123,7 @@ fn gpu_info_from_device(
         power_usage,
         power_limit,
         clock_freq,
-        processes: [compute_processes, graphics_processes].concat(),
+        processes,
     })
 }
 
@@ -120,11 +160,18 @@ pub fn collect_gpu_info(nvml: &Nvml, app_state: &mut AppState) -> Result<Vec<Gpu
     let previous_samples = app_state.cpu_samples.clone();
     let mut next_samples = HashMap::new();
 
+    let cpu_monitoring = app_state.cpu_monitoring;
+
     for index in 0..device_count {
         let device = nvml.device_by_index(index as u32)?;
 
-        let gpu_info =
-            gpu_info_from_device(index, device, &previous_samples, &mut next_samples)?;
+        let gpu_info = gpu_info_from_device(
+            index,
+            device,
+            &previous_samples,
+            &mut next_samples,
+            cpu_monitoring,
+        )?;
 
         // Update historical data
         if app_state.power_history.len() <= index {
@@ -151,7 +198,10 @@ pub fn collect_gpu_info(nvml: &Nvml, app_state: &mut AppState) -> Result<Vec<Gpu
         app_state.utilization_history.truncate(device_count);
     }
 
-    app_state.cpu_samples = next_samples;
+    // Per-process CPU samples only matter in GPU-only mode.
+    if !cpu_monitoring {
+        app_state.cpu_samples = next_samples;
+    }
 
     Ok(gpu_infos)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod error;
 mod gpu;
 mod influx_local;
 mod keybinds;
+mod system_monitor;
 mod ui;
 mod utils;
 
@@ -57,6 +58,13 @@ fn main() -> Result<()> {
                 .action(clap::ArgAction::SetTrue),
         )
         .arg(
+            Arg::new("cpu")
+                .short('c')
+                .long("cpu")
+                .help("Enable CPU and system-wide process monitoring (CPU panels, system process tray, sort with 's', and system metrics streaming)")
+                .action(clap::ArgAction::SetTrue),
+        )
+        .arg(
             Arg::new("influx-url")
                 .long("influx-url")
                 .value_name("URL")
@@ -89,7 +97,7 @@ fn main() -> Result<()> {
     let watch_interval = matches
         .get_one::<String>("watch")
         .map(|s| s.parse().expect("Invalid number"))
-        .unwrap_or(1000);
+        .unwrap_or(300);
 
     let nvml = Nvml::init()?;
 
@@ -138,7 +146,7 @@ fn main() -> Result<()> {
                     width: size.width,
                     height: size.height,
                 };
-                let max_scroll = help_max_scroll(help_area);
+                let max_scroll = help_max_scroll(help_area, app_state.cpu_monitoring);
                 let page = help_area.height.saturating_sub(2).max(1);
 
                 match key.code {
@@ -217,8 +225,10 @@ fn main() -> Result<()> {
                         }
                     }
                     KeybindAggregate::Right => {
+                        // `+ 1 <` rather than `< len() - 1` so we never underflow
+                        // when gpu_infos is empty.
                         if app_state.use_tabbed_graphs
-                            && app_state.selected_gpu_tab < app_state.gpu_infos.len() - 1
+                            && app_state.selected_gpu_tab + 1 < app_state.gpu_infos.len()
                         {
                             app_state.selected_gpu_tab += 1;
                         }
@@ -279,6 +289,10 @@ fn main() -> Result<()> {
                     app_state.use_tabbed_graphs = false;
                     app_state.use_bar_charts = true;
                 }
+                KeyCode::Char('s') if app_state.cpu_monitoring && !ctrl => {
+                    app_state.pending_op = PendingOp::None;
+                    app_state.cycle_sort_mode();
+                }
                 _ => {}
             }
         }
@@ -291,12 +305,15 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-/// Kill the process under the current selection (display order). Surfaces a UI
+/// Kill the process under the current selection (active tray order). Surfaces a UI
 /// error when the selection is stale (e.g. the process exited between frames).
 fn kill_highlighted_process(app_state: &mut AppState) {
-    match app_state.selected_process_entry() {
-        Some((_gpu, process)) => {
-            if let Err(e) = kill_selected_process(process.pid, &process.command) {
+    match app_state.selected_kill_target() {
+        Some((pid, command)) => {
+            // Clone command: kill_selected_process takes &str but we drop the
+            // borrow before mutating error_message.
+            let command = command.to_string();
+            if let Err(e) = kill_selected_process(pid, &command) {
                 app_state.error_message = Some(e.to_string());
             }
         }

--- a/src/system_monitor.rs
+++ b/src/system_monitor.rs
@@ -1,0 +1,532 @@
+//! System-wide CPU / memory / process scanning used by `--cpu` mode.
+
+use crate::app_state::AppState;
+use crate::error::NviError;
+use crate::gpu::info::GpuInfo;
+use nix::unistd::{Uid, User};
+use procfs::prelude::*;
+use procfs::process::{all_processes, Process};
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Number of processes kept in the bottom tray. We scan every process cheaply
+/// (one /proc/<pid>/stat read each) to compute CPU%, but only the busiest
+/// `TOP_N` are enriched with username + cmdline and rendered.
+const TOP_N: usize = 50;
+
+/// Width of a per-core meter bar in characters.
+const BAR_WIDTH: usize = 6;
+
+/// Max samples for the aggregate CPU% history graph (mirrors GPU history).
+const HISTORY_CAP: usize = 60;
+
+/// How the system process tray is ordered.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum SortMode {
+    #[default]
+    Cpu,
+    GpuMemory,
+}
+
+/// Cumulative CPU-time snapshot for deriving a percentage from the delta between ticks.
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq)]
+pub struct KernelCpuSample {
+    pub total: u64,
+    pub idle: u64,
+}
+
+/// System-wide CPU + memory snapshot for the left-hand panels.
+#[derive(Default, Clone)]
+pub struct CpuStats {
+    pub model: String,
+    pub logical_cores: usize,
+    pub per_core_usage: Vec<f32>,
+    pub aggregate_usage: f32,
+    pub frequency_mhz: f64,
+    pub load_avg: (f32, f32, f32),
+    pub mem_total: u64,
+    pub mem_used: u64,
+    pub swap_total: u64,
+    pub swap_used: u64,
+}
+
+/// A unified process row for the `--cpu` bottom tray.
+#[derive(Clone, Debug)]
+pub struct SystemProcess {
+    pub pid: i32,
+    pub gpu_memory: Option<u64>,
+    pub gpu_index: Option<usize>,
+    pub username: String,
+    pub command: String,
+    pub cpu_usage: f32,
+    pub memory_usage: u64,
+    pub state: char,
+}
+
+/// Sort a process slice in place by the active mode.
+pub fn sort_processes(procs: &mut [SystemProcess], mode: SortMode) {
+    // PID is a stable tie-breaker so near-idle rows don't reshuffle every tick
+    // when CPU% is equal (or both round to the same display value).
+    match mode {
+        SortMode::Cpu => procs.sort_by(|a, b| {
+            b.cpu_usage
+                .partial_cmp(&a.cpu_usage)
+                .unwrap_or(Ordering::Equal)
+                .then_with(|| a.pid.cmp(&b.pid))
+        }),
+        SortMode::GpuMemory => procs.sort_by(|a, b| {
+            b.gpu_memory
+                .unwrap_or(0)
+                .cmp(&a.gpu_memory.unwrap_or(0))
+                .then_with(|| {
+                    b.cpu_usage
+                        .partial_cmp(&a.cpu_usage)
+                        .unwrap_or(Ordering::Equal)
+                })
+                .then_with(|| a.pid.cmp(&b.pid))
+        }),
+    }
+}
+
+/// Width (in chars) of one per-core meter cell.
+pub fn meter_cell_width() -> usize {
+    // " 12[||||  ] 88% " -> 3 + 1 + BAR_WIDTH + 1 + 4 + 1
+    3 + 1 + BAR_WIDTH + 1 + 4 + 1
+}
+
+/// Build the filled/empty bar string for a single core meter.
+pub fn meter_bar(pct: f32) -> (String, String) {
+    let filled = ((pct / 100.0) * BAR_WIDTH as f32).round() as usize;
+    let filled = filled.min(BAR_WIDTH);
+    ("|".repeat(filled), " ".repeat(BAR_WIDTH - filled))
+}
+
+/// Collect CPU stats, system memory, and the top-N process list.
+pub fn collect_system_stats(app_state: &mut AppState) -> Result<(), NviError> {
+    let ks = procfs::KernelStats::current().map_err(|e| NviError::General(e.to_string()))?;
+    let cur_total = kernel_cpu_sample(&ks.total);
+    let total_delta = app_state
+        .prev_cpu_total
+        .as_ref()
+        .map(|p| cur_total.total.saturating_sub(p.total))
+        .unwrap_or(0);
+    let aggregate_usage = app_state
+        .prev_cpu_total
+        .as_ref()
+        .map(|p| pct(p, &cur_total))
+        .unwrap_or(0.0);
+    let logical_cores = ks.cpu_time.len();
+    let cur_per_core: Vec<KernelCpuSample> = ks.cpu_time.iter().map(kernel_cpu_sample).collect();
+    let per_core_usage: Vec<f32> = cur_per_core
+        .iter()
+        .enumerate()
+        .map(|(i, cur)| {
+            app_state
+                .prev_cpu_per_core
+                .get(i)
+                .map(|p| pct(p, cur))
+                .unwrap_or(0.0)
+        })
+        .collect();
+
+    let (model, frequency_mhz) =
+        read_cpu_model_freq().unwrap_or_else(|| ("Unknown CPU".to_string(), 0.0));
+    let load_avg = procfs::LoadAverage::current()
+        .map(|l| (l.one, l.five, l.fifteen))
+        .unwrap_or((0.0, 0.0, 0.0));
+    let mem = procfs::Meminfo::current().map_err(|e| NviError::General(e.to_string()))?;
+    let mem_total = mem.mem_total;
+    let mem_used = mem_total.saturating_sub(mem.mem_available.unwrap_or(mem.mem_free));
+    let swap_total = mem.swap_total;
+    let swap_used = swap_total.saturating_sub(mem.swap_free);
+
+    let gpu_map = build_gpu_map(&app_state.gpu_infos);
+    let page = procfs::page_size();
+    let mut procs: Vec<SystemProcess> = Vec::new();
+    let mut new_prev: HashMap<i32, u64> = HashMap::new();
+
+    if let Ok(iter) = all_processes() {
+        for p in iter.filter_map(|p| p.ok()) {
+            if let Ok(stat) = p.stat() {
+                let pid = stat.pid;
+                let ticks = stat.utime + stat.stime;
+                new_prev.insert(pid, ticks);
+
+                let cpu_usage = if total_delta > 0 {
+                    match app_state.prev_proc_times.get(&pid) {
+                        Some(&prev) => {
+                            (ticks.saturating_sub(prev) as f64 / total_delta as f64
+                                * logical_cores as f64
+                                * 100.0) as f32
+                        }
+                        None => 0.0,
+                    }
+                } else {
+                    0.0
+                };
+
+                let (gpu_memory, gpu_index) = match gpu_map.get(&pid) {
+                    Some(&(m, i)) => (Some(m), Some(i)),
+                    None => (None, None),
+                };
+
+                procs.push(SystemProcess {
+                    pid,
+                    gpu_memory,
+                    gpu_index,
+                    username: String::new(),
+                    command: stat.comm.clone(),
+                    cpu_usage,
+                    memory_usage: stat.rss * page,
+                    state: stat.state,
+                });
+            }
+        }
+    }
+
+    sort_processes(&mut procs, app_state.sort_mode);
+    procs.truncate(TOP_N);
+
+    for proc in procs.iter_mut() {
+        match Process::new(proc.pid) {
+            Ok(process) => {
+                if let Ok(uid) = process.uid() {
+                    proc.username = username_for(uid, &mut app_state.uid_cache);
+                }
+                match process.cmdline() {
+                    Ok(cmd) if !cmd.join(" ").is_empty() => proc.command = cmd.join(" "),
+                    _ => proc.command = format!("[{}]", proc.command),
+                }
+            }
+            Err(_) => proc.command = format!("[{}]", proc.command),
+        }
+    }
+
+    app_state.cpu_stats = CpuStats {
+        model,
+        logical_cores,
+        per_core_usage,
+        aggregate_usage,
+        frequency_mhz,
+        load_avg,
+        mem_total,
+        mem_used,
+        swap_total,
+        swap_used,
+    };
+    // Skip the bootstrap sample (always 0% — no prior delta) so the history
+    // graph doesn't fill with a flat zero line before real readings exist.
+    let had_baseline = app_state.prev_cpu_total.is_some();
+
+    app_state.prev_cpu_total = Some(cur_total);
+    app_state.prev_cpu_per_core = cur_per_core;
+    app_state.prev_proc_times = new_prev;
+    app_state.processes = procs;
+
+    if had_baseline {
+        // Keep sub-percent precision; rounding to u64 made idle ~0.3% look like 0.
+        app_state
+            .cpu_usage_history
+            .push(f64::from(aggregate_usage).clamp(0.0, 100.0));
+        while app_state.cpu_usage_history.len() > HISTORY_CAP {
+            app_state.cpu_usage_history.remove(0);
+        }
+    }
+
+    Ok(())
+}
+
+/// Build an InfluxDB write for system-wide CPU/memory (used with `--cpu` + Influx).
+pub fn system_metrics_write_query(cpu: &CpuStats) -> influxdb::WriteQuery {
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_else(|_| std::time::Duration::from_secs(0))
+        .as_nanos();
+
+    influxdb::WriteQuery::new(influxdb::Timestamp::Nanoseconds(ts), "system_metrics")
+        .add_field("cpu_usage", cpu.aggregate_usage as f64)
+        .add_field("cpu_freq", cpu.frequency_mhz)
+        .add_field("mem_used", cpu.mem_used as i64)
+        .add_field("mem_total", cpu.mem_total as i64)
+        .add_field("swap_used", cpu.swap_used as i64)
+        .add_field("swap_total", cpu.swap_total as i64)
+        .add_field("load_1", cpu.load_avg.0 as f64)
+}
+
+fn kernel_cpu_sample(t: &procfs::CpuTime) -> KernelCpuSample {
+    let idle = t.idle + t.iowait.unwrap_or(0);
+    let total = t.user
+        + t.nice
+        + t.system
+        + t.idle
+        + t.iowait.unwrap_or(0)
+        + t.irq.unwrap_or(0)
+        + t.softirq.unwrap_or(0)
+        + t.steal.unwrap_or(0);
+    KernelCpuSample { total, idle }
+}
+
+/// Percentage busy between two cumulative samples.
+fn pct(prev: &KernelCpuSample, cur: &KernelCpuSample) -> f32 {
+    let dt = cur.total.saturating_sub(prev.total);
+    let di = cur.idle.saturating_sub(prev.idle).min(dt);
+    if dt == 0 {
+        0.0
+    } else {
+        ((dt - di) as f64 / dt as f64 * 100.0) as f32
+    }
+}
+
+fn read_cpu_model_freq() -> Option<(String, f64)> {
+    let info = procfs::CpuInfo::current().ok()?;
+    let model = info.model_name(0).unwrap_or("Unknown CPU").to_string();
+    let mut sum = 0.0;
+    let mut count = 0u32;
+    for i in 0..info.num_cores() {
+        if let Some(mhz) = info.get_field(i, "cpu MHz") {
+            if let Ok(v) = mhz.trim().parse::<f64>() {
+                sum += v;
+                count += 1;
+            }
+        }
+    }
+    let freq = if count > 0 { sum / count as f64 } else { 0.0 };
+    Some((model, freq))
+}
+
+/// Map PID -> (total_used_gpu_memory, gpu_index) from NVML-collected GPU process lists.
+pub fn build_gpu_map(gpu_infos: &[GpuInfo]) -> HashMap<i32, (u64, usize)> {
+    let mut acc: HashMap<i32, (u64, usize, u64)> = HashMap::new();
+    for gpu in gpu_infos {
+        for proc in &gpu.processes {
+            let pid = proc.pid as i32;
+            let mem = proc.used_gpu_memory;
+            acc.entry(pid)
+                .and_modify(|e| {
+                    e.0 += mem;
+                    if mem > e.2 {
+                        e.1 = gpu.index;
+                        e.2 = mem;
+                    }
+                })
+                .or_insert((mem, gpu.index, mem));
+        }
+    }
+    acc.into_iter()
+        .map(|(pid, (total, idx, _))| (pid, (total, idx)))
+        .collect()
+}
+
+fn username_for(uid: u32, cache: &mut HashMap<u32, String>) -> String {
+    if let Some(name) = cache.get(&uid) {
+        return name.clone();
+    }
+    let name = User::from_uid(Uid::from_raw(uid))
+        .ok()
+        .flatten()
+        .map(|u| u.name)
+        .unwrap_or_else(|| uid.to_string());
+    cache.insert(uid, name.clone());
+    name
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gpu::GpuProcessInfo;
+
+    fn proc(cpu: f32, gpu: Option<u64>) -> SystemProcess {
+        SystemProcess {
+            pid: 1,
+            gpu_memory: gpu,
+            gpu_index: gpu.map(|_| 0),
+            username: String::new(),
+            command: String::new(),
+            cpu_usage: cpu,
+            memory_usage: 0,
+            state: 'R',
+        }
+    }
+
+    #[test]
+    fn test_pct_idle_only() {
+        let prev = KernelCpuSample { total: 0, idle: 0 };
+        let cur = KernelCpuSample {
+            total: 100,
+            idle: 100,
+        };
+        assert_eq!(pct(&prev, &cur), 0.0);
+    }
+
+    #[test]
+    fn test_pct_fully_busy() {
+        let prev = KernelCpuSample { total: 0, idle: 0 };
+        let cur = KernelCpuSample {
+            total: 100,
+            idle: 0,
+        };
+        assert_eq!(pct(&prev, &cur), 100.0);
+    }
+
+    #[test]
+    fn test_pct_half_busy() {
+        let prev = KernelCpuSample {
+            total: 200,
+            idle: 100,
+        };
+        let cur = KernelCpuSample {
+            total: 400,
+            idle: 200,
+        };
+        assert_eq!(pct(&prev, &cur), 50.0);
+    }
+
+    #[test]
+    fn test_pct_no_elapsed_time() {
+        let prev = KernelCpuSample {
+            total: 100,
+            idle: 50,
+        };
+        let cur = KernelCpuSample {
+            total: 100,
+            idle: 50,
+        };
+        assert_eq!(pct(&prev, &cur), 0.0);
+    }
+
+    #[test]
+    fn test_sort_by_cpu() {
+        let mut procs = vec![proc(10.0, None), proc(90.0, None), proc(50.0, None)];
+        sort_processes(&mut procs, SortMode::Cpu);
+        assert_eq!(procs[0].cpu_usage, 90.0);
+        assert_eq!(procs[1].cpu_usage, 50.0);
+        assert_eq!(procs[2].cpu_usage, 10.0);
+    }
+
+    #[test]
+    fn test_sort_by_gpu_memory_puts_gpu_procs_first() {
+        let mut procs = vec![
+            proc(99.0, None),
+            proc(1.0, Some(2048)),
+            proc(1.0, Some(8192)),
+        ];
+        sort_processes(&mut procs, SortMode::GpuMemory);
+        assert_eq!(procs[0].gpu_memory, Some(8192));
+        assert_eq!(procs[1].gpu_memory, Some(2048));
+        assert_eq!(procs[2].gpu_memory, None);
+    }
+
+    #[test]
+    fn test_sort_by_cpu_stable_on_ties() {
+        let mut procs = vec![
+            SystemProcess {
+                pid: 30,
+                gpu_memory: None,
+                gpu_index: None,
+                username: String::new(),
+                command: String::new(),
+                cpu_usage: 5.0,
+                memory_usage: 0,
+                state: 'R',
+            },
+            SystemProcess {
+                pid: 10,
+                gpu_memory: None,
+                gpu_index: None,
+                username: String::new(),
+                command: String::new(),
+                cpu_usage: 5.0,
+                memory_usage: 0,
+                state: 'R',
+            },
+            SystemProcess {
+                pid: 20,
+                gpu_memory: None,
+                gpu_index: None,
+                username: String::new(),
+                command: String::new(),
+                cpu_usage: 5.0,
+                memory_usage: 0,
+                state: 'R',
+            },
+        ];
+        sort_processes(&mut procs, SortMode::Cpu);
+        assert_eq!(
+            procs.iter().map(|p| p.pid).collect::<Vec<_>>(),
+            vec![10, 20, 30]
+        );
+    }
+
+    #[test]
+    fn test_meter_bar_clamps() {
+        let (filled, empty) = meter_bar(50.0);
+        assert_eq!(filled.len() + empty.len(), BAR_WIDTH);
+        let (filled, _) = meter_bar(150.0);
+        assert_eq!(filled.len(), BAR_WIDTH);
+        let (filled, empty) = meter_bar(0.0);
+        assert_eq!(filled.len(), 0);
+        assert_eq!(empty.len(), BAR_WIDTH);
+    }
+
+    #[test]
+    fn test_build_gpu_map_sums_and_picks_dominant() {
+        let gpus = vec![
+            GpuInfo {
+                index: 0,
+                name: "A".into(),
+                temperature: 0,
+                utilization: 0,
+                memory_used: 0,
+                memory_total: 0,
+                power_usage: 0,
+                power_limit: 0,
+                clock_freq: 0,
+                processes: vec![GpuProcessInfo {
+                    pid: 42,
+                    used_gpu_memory: 100,
+                    username: String::new(),
+                    command: String::new(),
+                    cpu_percent: None,
+                    memory_usage: 0,
+                }],
+            },
+            GpuInfo {
+                index: 1,
+                name: "B".into(),
+                temperature: 0,
+                utilization: 0,
+                memory_used: 0,
+                memory_total: 0,
+                power_usage: 0,
+                power_limit: 0,
+                clock_freq: 0,
+                processes: vec![GpuProcessInfo {
+                    pid: 42,
+                    used_gpu_memory: 500,
+                    username: String::new(),
+                    command: String::new(),
+                    cpu_percent: None,
+                    memory_usage: 0,
+                }],
+            },
+        ];
+        let map = build_gpu_map(&gpus);
+        assert_eq!(map.get(&42), Some(&(600, 1)));
+    }
+
+    #[test]
+    fn test_system_metrics_write_query_builds() {
+        let stats = CpuStats {
+            aggregate_usage: 12.5,
+            frequency_mhz: 2400.0,
+            mem_used: 1024,
+            mem_total: 4096,
+            swap_used: 0,
+            swap_total: 0,
+            load_avg: (0.5, 0.4, 0.3),
+            ..Default::default()
+        };
+        let _q = system_metrics_write_query(&stats);
+    }
+}

--- a/src/system_monitor.rs
+++ b/src/system_monitor.rs
@@ -141,68 +141,7 @@ pub fn collect_system_stats(app_state: &mut AppState) -> Result<(), NviError> {
     let swap_total = mem.swap_total;
     let swap_used = swap_total.saturating_sub(mem.swap_free);
 
-    let gpu_map = build_gpu_map(&app_state.gpu_infos);
-    let page = procfs::page_size();
-    let mut procs: Vec<SystemProcess> = Vec::new();
-    let mut new_prev: HashMap<i32, u64> = HashMap::new();
-
-    if let Ok(iter) = all_processes() {
-        for p in iter.filter_map(|p| p.ok()) {
-            if let Ok(stat) = p.stat() {
-                let pid = stat.pid;
-                let ticks = stat.utime + stat.stime;
-                new_prev.insert(pid, ticks);
-
-                let cpu_usage = if total_delta > 0 {
-                    match app_state.prev_proc_times.get(&pid) {
-                        Some(&prev) => {
-                            (ticks.saturating_sub(prev) as f64 / total_delta as f64
-                                * logical_cores as f64
-                                * 100.0) as f32
-                        }
-                        None => 0.0,
-                    }
-                } else {
-                    0.0
-                };
-
-                let (gpu_memory, gpu_index) = match gpu_map.get(&pid) {
-                    Some(&(m, i)) => (Some(m), Some(i)),
-                    None => (None, None),
-                };
-
-                procs.push(SystemProcess {
-                    pid,
-                    gpu_memory,
-                    gpu_index,
-                    username: String::new(),
-                    command: stat.comm.clone(),
-                    cpu_usage,
-                    memory_usage: stat.rss * page,
-                    state: stat.state,
-                });
-            }
-        }
-    }
-
-    sort_processes(&mut procs, app_state.sort_mode);
-    procs.truncate(TOP_N);
-
-    for proc in procs.iter_mut() {
-        match Process::new(proc.pid) {
-            Ok(process) => {
-                if let Ok(uid) = process.uid() {
-                    proc.username = username_for(uid, &mut app_state.uid_cache);
-                }
-                match process.cmdline() {
-                    Ok(cmd) if !cmd.join(" ").is_empty() => proc.command = cmd.join(" "),
-                    _ => proc.command = format!("[{}]", proc.command),
-                }
-            }
-            Err(_) => proc.command = format!("[{}]", proc.command),
-        }
-    }
-
+    // Commit CPU / memory panels even if the process scan fails below.
     app_state.cpu_stats = CpuStats {
         model,
         logical_cores,
@@ -215,17 +154,11 @@ pub fn collect_system_stats(app_state: &mut AppState) -> Result<(), NviError> {
         swap_total,
         swap_used,
     };
-    // Skip the bootstrap sample (always 0% — no prior delta) so the history
-    // graph doesn't fill with a flat zero line before real readings exist.
     let had_baseline = app_state.prev_cpu_total.is_some();
-
     app_state.prev_cpu_total = Some(cur_total);
     app_state.prev_cpu_per_core = cur_per_core;
-    app_state.prev_proc_times = new_prev;
-    app_state.processes = procs;
 
     if had_baseline {
-        // Keep sub-percent precision; rounding to u64 made idle ~0.3% look like 0.
         app_state
             .cpu_usage_history
             .push(f64::from(aggregate_usage).clamp(0.0, 100.0));
@@ -234,7 +167,85 @@ pub fn collect_system_stats(app_state: &mut AppState) -> Result<(), NviError> {
         }
     }
 
+    let gpu_map = build_gpu_map(&app_state.gpu_infos);
+    let page = procfs::page_size();
+    let mut procs: Vec<SystemProcess> = Vec::new();
+    let mut new_prev: HashMap<i32, u64> = HashMap::new();
+
+    let iter = all_processes().map_err(|e| {
+        // Keep the previous tray and CPU baselines so a transient /proc failure
+        // does not blank process monitoring or reset %CPU deltas.
+        NviError::General(format!("Process list unavailable: {e}"))
+    })?;
+
+    for p in iter.filter_map(|p| p.ok()) {
+        if let Ok(stat) = p.stat() {
+            let pid = stat.pid;
+            let ticks = stat.utime + stat.stime;
+            new_prev.insert(pid, ticks);
+
+            let cpu_usage = if total_delta > 0 {
+                match app_state.prev_proc_times.get(&pid) {
+                    Some(&prev) => {
+                        (ticks.saturating_sub(prev) as f64 / total_delta as f64
+                            * logical_cores as f64
+                            * 100.0) as f32
+                    }
+                    None => 0.0,
+                }
+            } else {
+                0.0
+            };
+
+            let (gpu_memory, gpu_index) = match gpu_map.get(&pid) {
+                Some(&(m, i)) => (Some(m), Some(i)),
+                None => (None, None),
+            };
+
+            procs.push(SystemProcess {
+                pid,
+                gpu_memory,
+                gpu_index,
+                username: String::new(),
+                command: stat.comm.clone(),
+                cpu_usage,
+                memory_usage: stat.rss * page,
+                state: stat.state,
+            });
+        }
+    }
+
+    app_state.prev_proc_times = new_prev;
+    app_state.process_scan = procs;
+    rebuild_process_tray(app_state);
+
     Ok(())
+}
+
+/// Sort the last full scan by the active mode, keep top N, and enrich for display.
+pub fn rebuild_process_tray(app_state: &mut AppState) {
+    let mut procs = app_state.process_scan.clone();
+    sort_processes(&mut procs, app_state.sort_mode);
+    procs.truncate(TOP_N);
+    enrich_processes(&mut procs, &mut app_state.uid_cache);
+    app_state.processes = procs;
+}
+
+fn enrich_processes(procs: &mut [SystemProcess], uid_cache: &mut HashMap<u32, String>) {
+    for proc in procs.iter_mut() {
+        match Process::new(proc.pid) {
+            Ok(process) => {
+                if let Ok(uid) = process.uid() {
+                    proc.username = username_for(uid, uid_cache);
+                }
+                match process.cmdline() {
+                    Ok(cmd) if !cmd.join(" ").is_empty() => proc.command = cmd.join(" "),
+                    _ => proc.command = format!("[{}]", proc.command),
+                }
+            }
+            Err(_) => proc.command = format!("[{}]", proc.command),
+        }
+    }
 }
 
 /// Build an InfluxDB write for system-wide CPU/memory (used with `--cpu` + Influx).
@@ -513,6 +524,36 @@ mod tests {
         ];
         let map = build_gpu_map(&gpus);
         assert_eq!(map.get(&42), Some(&(600, 1)));
+    }
+
+    #[test]
+    fn test_rebuild_tray_repicks_top_n_after_sort_change() {
+        use crate::app_state::AppState;
+
+        let mut state = AppState::default();
+        // Simulate a full scan larger than what a tiny "top" would keep under CPU sort.
+        let mut scan = Vec::new();
+        for i in 0..10 {
+            scan.push(SystemProcess {
+                pid: i,
+                gpu_memory: if i == 9 { Some(9999) } else { None },
+                gpu_index: if i == 9 { Some(0) } else { None },
+                username: String::new(),
+                command: format!("p{i}"),
+                cpu_usage: (10 - i) as f32, // pid 0 highest CPU
+                memory_usage: 0,
+                state: 'R',
+            });
+        }
+        state.process_scan = scan;
+        state.sort_mode = SortMode::Cpu;
+        rebuild_process_tray(&mut state);
+        assert_eq!(state.processes[0].pid, 0);
+
+        state.sort_mode = SortMode::GpuMemory;
+        rebuild_process_tray(&mut state);
+        assert_eq!(state.processes[0].pid, 9);
+        assert_eq!(state.processes[0].gpu_memory, Some(9999));
     }
 
     #[test]

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -1,6 +1,9 @@
 use crate::app_state::AppState;
 use crate::gpu::info::GpuInfo;
-use crate::ui::widgets::{render_footer, render_gpu_graphs, render_help};
+use crate::system_monitor::SortMode;
+use crate::ui::widgets::{
+    render_cpu_info, render_cpu_utilization, render_footer, render_gpu_graphs, render_help,
+};
 use crate::utils::format_memory_size;
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -13,6 +16,9 @@ const GRAPHS_MIN: u16 = 8;
 /// Borders + header + ≥1 process row + footer line.
 const PROCESS_MIN: u16 = 6;
 const MIN_WIDTH: u16 = 72;
+/// Wider + taller floor for the split CPU|GPU layout.
+const CPU_MIN_WIDTH: u16 = 96;
+const CPU_MIN_HEIGHT: u16 = 28;
 
 /// Borders (2) + header (1) + one row per GPU (at least 1 placeholder when empty).
 fn gpu_info_height(num_gpus: usize) -> u16 {
@@ -23,18 +29,15 @@ fn required_height(num_gpus: usize) -> u16 {
     gpu_info_height(num_gpus) + GRAPHS_MIN + PROCESS_MIN
 }
 
-fn render_terminal_too_small(f: &mut Frame, area: Rect, required_h: u16) {
-    let need_w = area.width < MIN_WIDTH;
+fn render_terminal_too_small(f: &mut Frame, area: Rect, min_w: u16, required_h: u16) {
+    let need_w = area.width < min_w;
     let need_h = area.height < required_h;
     let size_hint = match (need_w, need_h) {
         (true, true) => format!(
-            "Need at least {MIN_WIDTH} cols × {required_h} rows\n(now {}×{})",
+            "Need at least {min_w} cols × {required_h} rows\n(now {}×{})",
             area.width, area.height
         ),
-        (true, false) => format!(
-            "Need at least {MIN_WIDTH} columns (now {})",
-            area.width
-        ),
+        (true, false) => format!("Need at least {min_w} columns (now {})", area.width),
         (false, true) => format!(
             "Need at least {required_h} rows (now {})",
             area.height
@@ -74,20 +77,30 @@ fn render_terminal_too_small(f: &mut Frame, area: Rect, required_h: u16) {
 }
 
 pub fn ui(f: &mut Frame, app_state: &AppState) {
+    if app_state.show_help {
+        // Help is usable even in a short terminal — scroll within the pane.
+        // Skip the main-dashboard minimum-size gate for this overlay.
+        render_help(f, f.area(), app_state.help_scroll, app_state.cpu_monitoring);
+        return;
+    }
+
+    if app_state.cpu_monitoring {
+        ui_with_cpu(f, app_state);
+    } else {
+        ui_gpu_only(f, app_state);
+    }
+}
+
+/// Upstream layout: GPU Info, GPU graphs, and the GPU process tray stacked
+/// vertically. This is the default (no `--cpu`) view.
+fn ui_gpu_only(f: &mut Frame, app_state: &AppState) {
     let area = f.area();
     let num_gpus = app_state.gpu_infos.len();
     let gpu_info_h = gpu_info_height(num_gpus);
     let required_h = required_height(num_gpus);
 
-    if app_state.show_help {
-        // Help is usable even in a short terminal — scroll within the pane.
-        // Skip the main-dashboard minimum-size gate for this overlay.
-        render_help(f, area, app_state.help_scroll);
-        return;
-    }
-
     if area.width < MIN_WIDTH || area.height < required_h {
-        render_terminal_too_small(f, area, required_h);
+        render_terminal_too_small(f, area, MIN_WIDTH, required_h);
         return;
     }
 
@@ -106,6 +119,48 @@ pub fn ui(f: &mut Frame, app_state: &AppState) {
     render_gpu_info(f, chunks[0], &app_state.gpu_infos);
     render_gpu_graphs(f, chunks[1], app_state);
     render_process_list(f, chunks[2], app_state);
+}
+
+/// `--cpu` layout: CPU panels (left) + GPU panels (right) over a full-width
+/// system-wide process tray.
+fn ui_with_cpu(f: &mut Frame, app_state: &AppState) {
+    let area = f.area();
+    if area.width < CPU_MIN_WIDTH || area.height < CPU_MIN_HEIGHT {
+        render_terminal_too_small(f, area, CPU_MIN_WIDTH, CPU_MIN_HEIGHT);
+        return;
+    }
+
+    let root = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(58), Constraint::Percentage(42)].as_ref())
+        .split(area);
+    let top = root[0];
+    let bottom = root[1];
+
+    let columns = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(42), Constraint::Percentage(58)].as_ref())
+        .split(top);
+    let left = columns[0];
+    let right = columns[1];
+
+    let left_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(7), Constraint::Min(0)].as_ref())
+        .split(left);
+    render_cpu_info(f, left_chunks[0], &app_state.cpu_stats);
+    render_cpu_utilization(f, left_chunks[1], app_state);
+
+    let num_gpus = app_state.gpu_infos.len() as u16;
+    let gpu_info_h = (num_gpus + 3).clamp(4, 12);
+    let right_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(gpu_info_h), Constraint::Min(0)].as_ref())
+        .split(right);
+    render_gpu_info(f, right_chunks[0], &app_state.gpu_infos);
+    render_gpu_graphs(f, right_chunks[1], app_state);
+
+    render_system_process_list(f, bottom, app_state);
 }
 
 pub fn render_gpu_info(f: &mut Frame, area: Rect, gpu_infos: &[GpuInfo]) {
@@ -247,6 +302,8 @@ pub fn render_gpu_info(f: &mut Frame, area: Rect, gpu_infos: &[GpuInfo]) {
 
     f.render_widget(table, gpu_area);
 }
+
+/// Default (GPU-only) process tray.
 pub fn render_process_list(f: &mut Frame, area: Rect, app_state: &AppState) {
     let layout = Layout::default()
         .direction(Direction::Vertical)
@@ -350,20 +407,168 @@ pub fn render_process_list(f: &mut Frame, area: Rect, app_state: &AppState) {
     .column_spacing(COL_GAP);
 
     if let Some(error_msg) = &app_state.error_message {
-        let error_text = textwrap::wrap(error_msg, process_area.width as usize - 2);
+        let wrap_width = (process_area.width as usize).saturating_sub(2).max(1);
+        let error_text = textwrap::wrap(error_msg, wrap_width);
         let error_paragraph = Paragraph::new(error_text.join("\n"))
             .style(Style::default().fg(Color::Red))
             .block(Block::default().borders(Borders::ALL).title("Error"));
-        let error_area = Rect {
-            x: process_area.x,
-            y: process_area.y + process_area.height - 3,
-            width: process_area.width,
-            height: 3,
-        };
-        f.render_widget(error_paragraph, error_area);
+        if process_area.height >= 3 {
+            let error_area = Rect {
+                x: process_area.x,
+                y: process_area.y + process_area.height - 3,
+                width: process_area.width,
+                height: 3,
+            };
+            f.render_widget(error_paragraph, error_area);
+        }
     }
 
     f.render_widget(table, process_area);
+    render_footer(f, footer_area, app_state);
+}
+
+/// `--cpu` process tray: unified system-wide list (already sorted by sort_mode).
+pub fn render_system_process_list(f: &mut Frame, area: Rect, app_state: &AppState) {
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(1)].as_ref())
+        .split(area);
+
+    let main_area = layout[0];
+    let footer_area = layout[1];
+
+    let sort_label = match app_state.sort_mode {
+        SortMode::Cpu => "CPU%",
+        SortMode::GpuMemory => "GPU mem",
+    };
+    let block = Block::default().borders(Borders::ALL).title(format!(
+        "Processes — top {} by {}",
+        app_state.processes.len(),
+        sort_label
+    ));
+    f.render_widget(block.clone(), main_area);
+    let process_area = block.inner(main_area);
+
+    let selected_style = if app_state.pending_op.is_pending() {
+        Style::default()
+            .bg(Color::Yellow)
+            .fg(Color::Black)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+            .bg(Color::DarkGray)
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD)
+    };
+
+    let rows: Vec<Row> = app_state
+        .processes
+        .iter()
+        .enumerate()
+        .map(|(index, p)| {
+            let gpu_col = match p.gpu_index {
+                Some(i) => i.to_string(),
+                None => "-".to_string(),
+            };
+            let gpu_mem_col = match p.gpu_memory {
+                Some(m) => format_memory_size(m),
+                None => "-".to_string(),
+            };
+
+            let cells = [
+                gpu_col,
+                p.pid.to_string(),
+                gpu_mem_col,
+                format!("{:.1}", p.cpu_usage),
+                format_memory_size(p.memory_usage),
+                p.username.clone(),
+                p.state.to_string(),
+                p.command.clone(),
+            ];
+
+            if index == app_state.selected_process {
+                Row::new(cells.into_iter().map(|text| Cell::from(text).style(selected_style)))
+                    .style(selected_style)
+            } else {
+                let [gpu, pid, gpu_mem, cpu, mem, user, state, cmd] = cells;
+                Row::new(vec![
+                    Cell::from(gpu).style(Style::default().fg(Color::Cyan)),
+                    Cell::from(pid).style(Style::default().fg(Color::Yellow)),
+                    Cell::from(gpu_mem).style(Style::default().fg(Color::Green)),
+                    Cell::from(cpu).style(Style::default().fg(Color::Magenta)),
+                    Cell::from(mem).style(Style::default().fg(Color::Blue)),
+                    Cell::from(user).style(Style::default().fg(Color::Red)),
+                    Cell::from(state).style(Style::default().fg(Color::Gray)),
+                    Cell::from(cmd),
+                ])
+            }
+        })
+        .collect();
+
+    let table = Table::new(
+        rows,
+        &[
+            Constraint::Length(4),
+            Constraint::Length(7),
+            Constraint::Length(9),
+            Constraint::Length(6),
+            Constraint::Length(9),
+            Constraint::Length(12),
+            Constraint::Length(2),
+            Constraint::Percentage(100),
+        ],
+    )
+    .header(Row::new(vec![
+        Cell::from("GPU").style(
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Cell::from("PID").style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Cell::from("GPU Mem").style(
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Cell::from("CPU%").style(
+            Style::default()
+                .fg(Color::Magenta)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Cell::from("Mem").style(
+            Style::default()
+                .fg(Color::Blue)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Cell::from("User").style(Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
+        Cell::from("S").style(Style::default().fg(Color::Gray).add_modifier(Modifier::BOLD)),
+        Cell::from("Command").style(Style::default().add_modifier(Modifier::BOLD)),
+    ]))
+    .column_spacing(1);
+
+    f.render_widget(table, process_area);
+
+    if let Some(error_msg) = &app_state.error_message {
+        let wrap_width = (process_area.width as usize).saturating_sub(2).max(1);
+        let error_text = textwrap::wrap(error_msg, wrap_width);
+        let error_paragraph = Paragraph::new(error_text.join("\n"))
+            .style(Style::default().fg(Color::Red))
+            .block(Block::default().borders(Borders::ALL).title("Error"));
+        if process_area.height >= 3 {
+            let error_area = Rect {
+                x: process_area.x,
+                y: process_area.y + process_area.height - 3,
+                width: process_area.width,
+                height: 3,
+            };
+            f.render_widget(error_paragraph, error_area);
+        }
+    }
+
     render_footer(f, footer_area, app_state);
 }
 

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -1,5 +1,7 @@
 use crate::app_state::AppState;
 use crate::gpu::info::GpuInfo;
+use crate::system_monitor::{meter_bar, meter_cell_width, CpuStats};
+use crate::utils::format_memory_size;
 use ratatui::Frame;
 use ratatui::layout::Rect;
 use ratatui::prelude::*;
@@ -17,10 +19,11 @@ pub fn render_gpu_graphs(f: &mut Frame, area: Rect, app_state: &AppState) {
 }
 pub fn render_gpu_bar_charts(f: &mut Frame, area: Rect, app_state: &AppState) {
     let gpu_count = app_state.gpu_infos.len();
-    // BUG: [div-by-zero] : render_gpu_bar_charts does not guard against gpu_count == 0;
-    //   100 / gpu_count on line below will panic if no GPUs are present.
-    //   Compare to render_all_gpu_graphs which has a guard.
     if gpu_count == 0 {
+        let paragraph = Paragraph::new("No GPUs found.")
+            .style(Style::default().fg(Color::Red))
+            .alignment(Alignment::Center);
+        f.render_widget(paragraph, area);
         return;
     }
     let chunks = Layout::default()
@@ -79,10 +82,14 @@ pub fn render_tabbed_gpu_graphs(f: &mut Frame, area: Rect, app_state: &AppState)
 }
 
 pub fn render_footer(f: &mut Frame, area: Rect, app_state: &AppState) {
-    let footer_text = if app_state.use_tabbed_graphs {
+    let footer_text = if app_state.cpu_monitoring {
+        if app_state.use_tabbed_graphs {
+            "↑↓: nav | ←→: tabs | s: sort | x: kill | ^d/t/b: modes | ?: help | q: quit"
+        } else {
+            "↑↓: nav | s: sort | x: kill | ^d/t/b: modes | ?: help | q: quit"
+        }
+    } else if app_state.use_tabbed_graphs {
         "↑↓: nav | ←→: tabs | x: kill | ^d/t/b: modes | ?: help | q: quit"
-    } else if app_state.use_bar_charts {
-        "↑↓: nav | x: kill | ^d/t/b: modes | ?: help | q: quit"
     } else {
         "↑↓: nav | x: kill | ^d/t/b: modes | ?: help | q: quit"
     };
@@ -97,8 +104,8 @@ pub fn render_footer(f: &mut Frame, area: Rect, app_state: &AppState) {
 ///
 /// Content can exceed the terminal height — callers pass a vertical scroll
 /// offset and we clamp it so ↑↓ / j k / PgUp/PgDn can reveal the rest.
-pub fn render_help(f: &mut Frame, area: Rect, scroll: u16) {
-    let lines = help_lines();
+pub fn render_help(f: &mut Frame, area: Rect, scroll: u16, cpu_monitoring: bool) {
+    let lines = help_lines(cpu_monitoring);
     let content_h = lines.len() as u16;
     // Borders take 2 rows; remaining is the viewport for scrolled text.
     let viewport = area.height.saturating_sub(2);
@@ -124,13 +131,13 @@ pub fn render_help(f: &mut Frame, area: Rect, scroll: u16) {
 }
 
 /// Max scroll offset for the current help content in `area`.
-pub fn help_max_scroll(area: Rect) -> u16 {
-    let content_h = help_lines().len() as u16;
+pub fn help_max_scroll(area: Rect, cpu_monitoring: bool) -> u16 {
+    let content_h = help_lines(cpu_monitoring).len() as u16;
     let viewport = area.height.saturating_sub(2);
     content_h.saturating_sub(viewport)
 }
 
-fn help_lines() -> Vec<Line<'static>> {
+fn help_lines(cpu_monitoring: bool) -> Vec<Line<'static>> {
     let title = Style::default()
         .fg(Color::Cyan)
         .add_modifier(Modifier::BOLD);
@@ -141,7 +148,7 @@ fn help_lines() -> Vec<Line<'static>> {
     let note = Style::default().fg(Color::DarkGray);
     let sep = Style::default().fg(Color::DarkGray);
 
-    vec![
+    let mut lines = vec![
         Line::from(Span::styled("Navigation", title)),
         Line::from(""),
         Line::from(Span::styled("  Move process selection", action)),
@@ -191,6 +198,41 @@ fn help_lines() -> Vec<Line<'static>> {
             Span::styled("d d", key),
             Span::styled("  vim chord (press d twice)", note),
         ]),
+    ];
+
+    if cpu_monitoring {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled("Process tray  (--cpu)", title)));
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled("  Sort list", action)));
+        lines.push(Line::from(vec![
+            Span::raw("    "),
+            Span::styled("s", key),
+            Span::styled("    Top 50 by CPU%  ↔  top 50 by GPU memory", note),
+        ]));
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "  S column — process state",
+            action,
+        )));
+        // One letter per row: scannable, same indent rhythm as key rows above.
+        for (letter, meaning) in [
+            ("R", "    Running (or runnable on a CPU)"),
+            ("S", "    Sleeping (interruptible wait)"),
+            ("D", "    Disk sleep (uninterruptible I/O)"),
+            ("T", "    Stopped (job control / tracer)"),
+            ("Z", "    Zombie (exited, not reaped)"),
+            ("I", "    Idle kernel thread"),
+        ] {
+            lines.push(Line::from(vec![
+                Span::raw("    "),
+                Span::styled(letter, key),
+                Span::styled(meaning, note),
+            ]));
+        }
+    }
+
+    lines.extend([
         Line::from(""),
         Line::from(Span::styled("  Graph mode", action)),
         Line::from(vec![
@@ -222,7 +264,172 @@ fn help_lines() -> Vec<Line<'static>> {
             "  Tip: footer lists primary keys only; aliases live here.",
             note,
         )),
-    ]
+    ]);
+
+    lines
+}
+
+/// Top-left panel: CPU model, core count, frequency, load average, and memory/swap.
+pub fn render_cpu_info(f: &mut Frame, area: Rect, cpu: &CpuStats) {
+    let block = Block::default().borders(Borders::ALL).title("CPU Info");
+    f.render_widget(block.clone(), area);
+    let inner = block.inner(area);
+
+    let model = if cpu.model.is_empty() {
+        "Collecting...".to_string()
+    } else {
+        cpu.model.clone()
+    };
+    let mem_line = format!(
+        "Mem:  {} / {}",
+        format_memory_size(cpu.mem_used),
+        format_memory_size(cpu.mem_total)
+    );
+    let swap_line = if cpu.swap_total > 0 {
+        format!(
+            "Swap: {} / {}",
+            format_memory_size(cpu.swap_used),
+            format_memory_size(cpu.swap_total)
+        )
+    } else {
+        "Swap: none".to_string()
+    };
+
+    let lines = vec![
+        Line::from(Span::styled(
+            model,
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(format!(
+            "Cores: {}   Freq: {:.0} MHz",
+            cpu.logical_cores, cpu.frequency_mhz
+        )),
+        Line::from(format!(
+            "Load:  {:.2}  {:.2}  {:.2}",
+            cpu.load_avg.0, cpu.load_avg.1, cpu.load_avg.2
+        )),
+        Line::from(Span::styled(mem_line, Style::default().fg(Color::Blue))),
+        Line::from(Span::styled(swap_line, Style::default().fg(Color::Cyan))),
+    ];
+    f.render_widget(Paragraph::new(lines), inner);
+}
+
+/// Bottom-left panel: per-core meters over aggregate CPU% history.
+pub fn render_cpu_utilization(f: &mut Frame, area: Rect, app_state: &AppState) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(55), Constraint::Percentage(45)].as_ref())
+        .split(area);
+
+    render_cpu_meters(f, chunks[0], &app_state.cpu_stats);
+    render_cpu_graph(f, chunks[1], app_state);
+}
+
+fn load_color(pct: f32) -> Color {
+    if pct < 50.0 {
+        Color::Green
+    } else if pct < 85.0 {
+        Color::Yellow
+    } else {
+        Color::Red
+    }
+}
+
+fn render_cpu_meters(f: &mut Frame, area: Rect, cpu: &CpuStats) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!("CPU Utilization  ({:.0}%)", cpu.aggregate_usage));
+    f.render_widget(block.clone(), area);
+    let inner = block.inner(area);
+
+    let cores = cpu.per_core_usage.len();
+    if cores == 0 || inner.width == 0 {
+        f.render_widget(
+            Paragraph::new("Collecting...").style(Style::default().fg(Color::DarkGray)),
+            inner,
+        );
+        return;
+    }
+
+    let cols = (inner.width as usize / meter_cell_width()).max(1);
+    let rows_n = (cores + cols - 1) / cols;
+
+    let mut lines: Vec<Line> = Vec::with_capacity(rows_n);
+    for r in 0..rows_n {
+        let mut spans: Vec<Span> = Vec::new();
+        for c in 0..cols {
+            let idx = r * cols + c;
+            if idx >= cores {
+                break;
+            }
+            let pct = cpu.per_core_usage[idx];
+            let (filled, empty) = meter_bar(pct);
+            let color = load_color(pct);
+            spans.push(Span::styled(
+                format!("{:>3}[", idx),
+                Style::default().fg(Color::DarkGray),
+            ));
+            spans.push(Span::styled(filled, Style::default().fg(color)));
+            spans.push(Span::raw(empty));
+            spans.push(Span::styled(
+                format!("]{:>3.0}% ", pct),
+                Style::default().fg(color),
+            ));
+        }
+        lines.push(Line::from(spans));
+    }
+
+    f.render_widget(Paragraph::new(lines), inner);
+}
+
+fn render_cpu_graph(f: &mut Frame, area: Rect, app_state: &AppState) {
+    let data: Vec<(f64, f64)> = app_state
+        .cpu_usage_history
+        .iter()
+        .enumerate()
+        .map(|(i, &v)| (i as f64, v))
+        .collect();
+
+    let dataset = Dataset::default()
+        .name("CPU %")
+        .marker(symbols::Marker::Braille)
+        .graph_type(ratatui::widgets::GraphType::Line)
+        .style(Style::default().fg(Color::Green))
+        .data(&data);
+
+    let chart = Chart::new(vec![dataset])
+        .block(
+            Block::default()
+                .title("CPU History")
+                .borders(Borders::ALL),
+        )
+        .x_axis(
+            Axis::default()
+                .style(Style::default().fg(Color::Gray))
+                .bounds([0.0, 60.0])
+                .labels(
+                    ["0", "15", "30", "45", "60"]
+                        .iter()
+                        .map(|&s| s.to_string())
+                        .collect::<Vec<String>>(),
+                ),
+        )
+        .y_axis(
+            Axis::default()
+                .title("%")
+                .style(Style::default().fg(Color::Gray))
+                .bounds([0.0, 100.0])
+                .labels(
+                    ["0", "50", "100"]
+                        .iter()
+                        .map(|&s| s.to_string())
+                        .collect::<Vec<String>>(),
+                ),
+        );
+
+    f.render_widget(chart, area);
 }
 
 pub fn render_all_gpu_graphs(f: &mut Frame, area: Rect, app_state: &AppState) {
@@ -258,10 +465,14 @@ pub fn render_all_gpu_graphs(f: &mut Frame, area: Rect, app_state: &AppState) {
 }
 
 pub fn render_power_bar(f: &mut Frame, area: Rect, gpu_info: &GpuInfo, gpu_index: usize) {
-    let power_percentage = cmp::min(
-        100,
-        ((gpu_info.power_usage as f64 / gpu_info.power_limit as f64) * 100.0) as u16,
-    );
+    let power_percentage = if gpu_info.power_limit > 0 {
+        cmp::min(
+            100,
+            ((gpu_info.power_usage as f64 / gpu_info.power_limit as f64) * 100.0) as u16,
+        )
+    } else {
+        0
+    };
     let power_bar = Gauge::default()
         .block(
             Block::default()
@@ -306,6 +517,12 @@ pub fn render_power_graph(f: &mut Frame, area: Rect, app_state: &AppState, gpu_i
         .style(Style::default().fg(Color::Yellow))
         .data(&power_data);
 
+    let y_max = if gpu_info.power_limit > 0 {
+        gpu_info.power_limit as f64 * 1.1
+    } else {
+        1.0
+    };
+
     let power_chart = Chart::new(vec![power_dataset])
         .block(
             Block::default()
@@ -328,7 +545,7 @@ pub fn render_power_graph(f: &mut Frame, area: Rect, app_state: &AppState, gpu_i
             Axis::default()
                 .title("Power (W)")
                 .style(Style::default().fg(Color::Gray))
-                .bounds([0.0, gpu_info.power_limit as f64 * 1.1])
+                .bounds([0.0, y_max])
                 .labels(vec![
                     format!("{:.0}", 0.0),
                     format!("{:.0}", gpu_info.power_limit as f64 / 2.0),


### PR DESCRIPTION
## Summary
- Adds opt-in `-c` / `--cpu` monitoring: CPU/RAM panels, per-core meters + history, and a top-50 system process tray (sort with `s`: CPU% ↔ GPU memory), with optional InfluxDB `system_metrics`.
- Default (no flag) remains GPU-only; selection/kill (`x` / `dd`) and help/footer stay mode-aware.
- Ports and rebases the design from [#10](https://github.com/msminhas93/nviwatch/issues/10) by **[@jpswensen](https://github.com/jpswensen)** — thank you for the patch and the htop+gpustat idea. Applied against the current AppState/keybind architecture rather than applying the patch file as-is.
- Also: immediate first poll (no blank `--watch` startup delay), README watch default synced to 300 ms, and a note to pair `--cpu` with `--watch 1500` for a calmer process list.

## Test plan
- [ ] `cargo test`
- [ ] `cargo run --release --` — GPU-only UI unchanged
- [ ] `cargo run --release -- --cpu --watch 1500` — CPU panels + system tray; first frame not blank for 1.5s
- [ ] Press `s` — title/sort toggles top-50 by CPU% ↔ GPU memory; `?` shows S-column legend only in `--cpu` mode
- [ ] `x` / `dd` kill the highlighted system-tray row in `--cpu` mode
- [ ] With Influx flags + `--cpu`, confirm `system_metrics` points appear alongside `gpu_metrics` (if Influx is available)

Closes #10