### PR TITLE
Add Windows support via platform-split process backend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,3 +52,26 @@ jobs:
         asset_path: ./target/release/nviwatch
         asset_name: nviwatch
         asset_content_type: application/octet-stream
+
+  # Windows release binary. Additive: the Linux job above is unchanged.
+  # nvml-wrapper loads nvml.dll at runtime (dynamic linking), so the runner
+  # needs no NVIDIA driver or CUDA toolkit to build — only to run.
+  build-windows:
+    needs: build-and-release
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+
+    - name: Build Release
+      run: cargo build --release
+
+    - name: Upload Windows binary to release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh release upload "${{ github.event.inputs.release_tag }}" target/release/nviwatch.exe

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,6 +571,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,7 +996,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -1504,6 +1514,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1550,6 +1569,7 @@ dependencies = [
  "prettytable-rs",
  "procfs",
  "ratatui",
+ "sysinfo",
  "textwrap",
  "tokio",
 ]
@@ -1575,6 +1595,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b4d594420fcda43b1c2c4bd44d48974aa3c7a9ab2cbf10dc18e35265767bf0b"
 dependencies = [
  "libloading",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.13.1",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2595,6 +2672,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.39.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "objc2-open-directory",
+ "windows",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3253,6 +3345,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3262,10 +3375,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -3337,6 +3506,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,18 @@ categories = ["command-line-utilities", "visualization", "hardware-support"]
 [dependencies]
 clap = "4.6.5"
 crossterm = "0.29.0"
-nix = { version = "0.31.3", features = ["process", "signal", "user"] }
 nvml = { version = "0.12.1", package = "nvml-wrapper" }
 prettytable-rs = "0.10.0"
-procfs = "0.18.0"
 ratatui = "0.30.2"
 textwrap = "0.16.2"
 influxdb = { version = "0.8.0", features = ["derive"] }
 tokio = { version = "1.53.1", features = ["full"] }
+
+# Linux-only: /proc parsing (procfs) and POSIX wrappers (nix).
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.31.3", features = ["process", "signal", "user"] }
+procfs = "0.18.0"
+
+# Windows-only: cross-platform system probe backing the process/CPU backend.
+[target.'cfg(windows)'.dependencies]
+sysinfo = "0.39"

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ If you have Rust and Cargo installed on your system, you can easily install NviW
    nviwatch
    ```
 
-Note: Ensure you have the NVIDIA Management Library (NVML) available on your system before running NviWatch.
+Note: Ensure you have the NVIDIA Management Library (NVML) available on your system before running NviWatch. On Windows, `cargo install nviwatch` builds and runs as well; the `--cpu` view omits load average there, as it has no Windows equivalent.
 
 ### Option 3: Install via Conda, Mamba, or Pixi
 

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -5,8 +5,8 @@ use crate::gpu::info::{GpuInfo, collect_gpu_info};
 use crate::influx_local::{InfluxDBConfig, TempInfluxConfig};
 use crate::keybinds::PendingOp;
 use crate::system_monitor::{
-    collect_system_stats, rebuild_process_tray, system_metrics_write_query, CpuStats,
-    KernelCpuSample, SortMode, SystemProcess,
+    CpuStats, KernelCpuSample, SortMode, SystemProcess, collect_system_stats, rebuild_process_tray,
+    system_metrics_write_query,
 };
 use crate::utils::system::CpuSample;
 use nvml::Nvml;
@@ -183,9 +183,7 @@ impl AppState {
                 self.last_update = Some(std::time::Instant::now());
                 true
             }
-            Some(t)
-                if t.elapsed() >= std::time::Duration::from_millis(interval_ms) =>
-            {
+            Some(t) if t.elapsed() >= std::time::Duration::from_millis(interval_ms) => {
                 self.last_update = Some(std::time::Instant::now());
                 true
             }
@@ -372,10 +370,7 @@ mod tests {
             power_usage: 0,
             power_limit: 0,
             clock_freq: 0,
-            processes: vec![
-                gpu_proc(10, 100, "small"),
-                gpu_proc(20, 900, "big"),
-            ],
+            processes: vec![gpu_proc(10, 100, "small"), gpu_proc(20, 900, "big")],
         });
         // Display order is GPU-memory desc → big first.
         state.selected_process = 0;

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -212,10 +212,10 @@ impl AppState {
     ) -> Result<()> {
         self.gpu_infos = collect_gpu_info(nvml, self)?;
 
-        if self.cpu_monitoring {
-            if let Err(e) = collect_system_stats(self) {
-                self.error_message = Some(format!("System info error: {e}"));
-            }
+        if self.cpu_monitoring
+            && let Err(e) = collect_system_stats(self)
+        {
+            self.error_message = Some(format!("System info error: {e}"));
         }
 
         self.clamp_selection();
@@ -296,8 +296,10 @@ mod tests {
 
     #[test]
     fn test_app_state_initialization() {
-        let mut state = AppState::default();
-        state.use_tabbed_graphs = true;
+        let state = AppState {
+            use_tabbed_graphs: true,
+            ..Default::default()
+        };
 
         assert_eq!(state.selected_process, 0);
         assert_eq!(state.selected_gpu_tab, 0);
@@ -330,8 +332,10 @@ mod tests {
 
     #[test]
     fn test_total_processes_cpu_mode_uses_system_list() {
-        let mut state = AppState::default();
-        state.cpu_monitoring = true;
+        let mut state = AppState {
+            cpu_monitoring: true,
+            ..Default::default()
+        };
         state.gpu_infos.push(GpuInfo {
             index: 0,
             name: "G".into(),
@@ -381,8 +385,10 @@ mod tests {
 
     #[test]
     fn test_selected_kill_target_cpu_mode() {
-        let mut state = AppState::default();
-        state.cpu_monitoring = true;
+        let mut state = AppState {
+            cpu_monitoring: true,
+            ..Default::default()
+        };
         state.processes.push(SystemProcess {
             pid: 7,
             gpu_memory: None,
@@ -452,8 +458,8 @@ mod tests {
         let state = AppState::default();
         // Should not be able to select any process when there are no GPUs
         let total_processes = state.total_process_count();
-        assert!(!(0 < total_processes));
-        assert!(!(1 < total_processes));
+        assert!(total_processes == 0);
+        assert!(total_processes <= 1);
     }
 
     #[test]

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -48,6 +48,11 @@ pub struct AppState {
     pub cpu_usage_history: Vec<f64>,
     pub prev_cpu_total: Option<KernelCpuSample>,
     pub prev_cpu_per_core: Vec<KernelCpuSample>,
+    /// Prior per-process cumulative CPU times (`/proc`-style) for top-style
+    /// %CPU deltas in the `--cpu` process scan. Unix-only: the Windows
+    /// backend gets process deltas from sysinfo directly, so nothing reads
+    /// this map there.
+    #[cfg_attr(windows, allow(dead_code))]
     pub prev_proc_times: HashMap<i32, u64>,
     pub uid_cache: HashMap<u32, String>,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,6 +52,7 @@ impl From<std::io::Error> for NviError {
     }
 }
 
+#[cfg(unix)]
 impl From<nix::errno::Errno> for NviError {
     fn from(e: nix::errno::Errno) -> Self {
         Self::Process(e.to_string())

--- a/src/gpu/info.rs
+++ b/src/gpu/info.rs
@@ -97,7 +97,7 @@ fn gpu_info_from_device(
             device
                 .running_compute_processes()?
                 .into_iter()
-                .chain(device.running_graphics_processes()?.into_iter()),
+                .chain(device.running_graphics_processes()?),
         )
     } else {
         let compute_processes = collect_gpu_processes(

--- a/src/influx_local.rs
+++ b/src/influx_local.rs
@@ -11,10 +11,7 @@ pub struct TempInfluxConfig {
 impl TempInfluxConfig {
     /// True when all four `--influx-*` flags were provided (values may still be empty).
     pub fn flags_complete(&self) -> bool {
-        self.url.is_some()
-            && self.org.is_some()
-            && self.bucket.is_some()
-            && self.token.is_some()
+        self.url.is_some() && self.org.is_some() && self.bucket.is_some() && self.token.is_some()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,7 +205,7 @@ fn main() -> Result<()> {
                 }
             }
 
-            if let Some(nav) = KeybindAggregate::try_from(&key).ok() {
+            if let Ok(nav) = KeybindAggregate::try_from(&key) {
                 app_state.pending_op = PendingOp::None;
                 match nav {
                     KeybindAggregate::Up => {

--- a/src/system_monitor.rs
+++ b/src/system_monitor.rs
@@ -369,9 +369,9 @@ mod imp {
     };
     use crate::app_state::AppState;
     use crate::error::NviError;
-    use crate::utils::system::with_probe;
+    use crate::utils::system::{process_refresh_kind, with_probe};
     use std::collections::HashMap;
-    use sysinfo::{ProcessStatus, ProcessesToUpdate};
+    use sysinfo::{CpuRefreshKind, ProcessStatus, ProcessesToUpdate};
 
     /// Collect CPU stats, system memory, and the top-N process list.
     pub fn collect_system_stats(app_state: &mut AppState) -> Result<(), NviError> {
@@ -382,16 +382,30 @@ mod imp {
             // One pass: CPU deltas, memory, and the full process table. sysinfo
             // computes cpu_usage internally across refreshes, so the first tick
             // after startup reads zero (mirrors the unix baseline gate below).
-            probe.system.refresh_cpu_usage();
-            probe.system.refresh_memory();
+            // `everything()` also fetches per-core frequency (the CPUInfo
+            // panel's Freq field); `refresh_cpu_usage()` alone leaves it 0.
             probe
                 .system
-                .refresh_processes(ProcessesToUpdate::All, false);
+                .refresh_cpu_specifics(CpuRefreshKind::everything());
+            probe.system.refresh_memory();
+            probe.system.refresh_processes_specifics(
+                ProcessesToUpdate::All,
+                false,
+                process_refresh_kind(),
+            );
             // Populate the user table once per session so `enrich_processes`
             // (called via `rebuild_process_tray` below) can resolve usernames.
             probe.ensure_users();
 
             app_state.cpu_stats = cpu_stats_from_system(&probe.system);
+            // PDH counters need two collection cycles before per-core usage is
+            // meaningful; the first tick can report 100% across the board. The
+            // unix backend shows 0.0% on its first tick (no baseline yet), so
+            // zero the Windows first tick too to keep the panels aligned.
+            if !had_baseline {
+                app_state.cpu_stats.per_core_usage = vec![0.0; app_state.cpu_stats.logical_cores];
+                app_state.cpu_stats.aggregate_usage = 0.0;
+            }
 
             let mut procs: Vec<SystemProcess> = Vec::new();
             for (pid, process) in probe.system.processes() {

--- a/src/system_monitor.rs
+++ b/src/system_monitor.rs
@@ -388,9 +388,13 @@ mod imp {
                 .system
                 .refresh_cpu_specifics(CpuRefreshKind::everything());
             probe.system.refresh_memory();
+            // remove_dead_processes = true: exited processes drop out of the
+            // table every tick, like the unix backend's fresh /proc scan —
+            // with false a dead process would keep its frozen last CPU% and
+            // pin the top of the tray for the rest of the session.
             probe.system.refresh_processes_specifics(
                 ProcessesToUpdate::All,
-                false,
+                true,
                 process_refresh_kind(),
             );
             // Populate the user table once per session so `enrich_processes`

--- a/src/system_monitor.rs
+++ b/src/system_monitor.rs
@@ -320,11 +320,11 @@ mod imp {
         let mut sum = 0.0;
         let mut count = 0u32;
         for i in 0..info.num_cores() {
-            if let Some(mhz) = info.get_field(i, "cpu MHz") {
-                if let Ok(v) = mhz.trim().parse::<f64>() {
-                    sum += v;
-                    count += 1;
-                }
+            if let Some(mhz) = info.get_field(i, "cpu MHz")
+                && let Ok(v) = mhz.trim().parse::<f64>()
+            {
+                sum += v;
+                count += 1;
             }
         }
         let freq = if count > 0 { sum / count as f64 } else { 0.0 };

--- a/src/system_monitor.rs
+++ b/src/system_monitor.rs
@@ -1,11 +1,7 @@
 //! System-wide CPU / memory / process scanning used by `--cpu` mode.
 
 use crate::app_state::AppState;
-use crate::error::NviError;
 use crate::gpu::info::GpuInfo;
-use nix::unistd::{Uid, User};
-use procfs::prelude::*;
-use procfs::process::{all_processes, Process};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -102,126 +98,6 @@ pub fn meter_bar(pct: f32) -> (String, String) {
     ("|".repeat(filled), " ".repeat(BAR_WIDTH - filled))
 }
 
-/// Collect CPU stats, system memory, and the top-N process list.
-pub fn collect_system_stats(app_state: &mut AppState) -> Result<(), NviError> {
-    let ks = procfs::KernelStats::current().map_err(|e| NviError::General(e.to_string()))?;
-    let cur_total = kernel_cpu_sample(&ks.total);
-    let total_delta = app_state
-        .prev_cpu_total
-        .as_ref()
-        .map(|p| cur_total.total.saturating_sub(p.total))
-        .unwrap_or(0);
-    let aggregate_usage = app_state
-        .prev_cpu_total
-        .as_ref()
-        .map(|p| pct(p, &cur_total))
-        .unwrap_or(0.0);
-    let logical_cores = ks.cpu_time.len();
-    let cur_per_core: Vec<KernelCpuSample> = ks.cpu_time.iter().map(kernel_cpu_sample).collect();
-    let per_core_usage: Vec<f32> = cur_per_core
-        .iter()
-        .enumerate()
-        .map(|(i, cur)| {
-            app_state
-                .prev_cpu_per_core
-                .get(i)
-                .map(|p| pct(p, cur))
-                .unwrap_or(0.0)
-        })
-        .collect();
-
-    let (model, frequency_mhz) =
-        read_cpu_model_freq().unwrap_or_else(|| ("Unknown CPU".to_string(), 0.0));
-    let load_avg = procfs::LoadAverage::current()
-        .map(|l| (l.one, l.five, l.fifteen))
-        .unwrap_or((0.0, 0.0, 0.0));
-    let mem = procfs::Meminfo::current().map_err(|e| NviError::General(e.to_string()))?;
-    let mem_total = mem.mem_total;
-    let mem_used = mem_total.saturating_sub(mem.mem_available.unwrap_or(mem.mem_free));
-    let swap_total = mem.swap_total;
-    let swap_used = swap_total.saturating_sub(mem.swap_free);
-
-    // Commit CPU / memory panels even if the process scan fails below.
-    app_state.cpu_stats = CpuStats {
-        model,
-        logical_cores,
-        per_core_usage,
-        aggregate_usage,
-        frequency_mhz,
-        load_avg,
-        mem_total,
-        mem_used,
-        swap_total,
-        swap_used,
-    };
-    let had_baseline = app_state.prev_cpu_total.is_some();
-    app_state.prev_cpu_total = Some(cur_total);
-    app_state.prev_cpu_per_core = cur_per_core;
-
-    if had_baseline {
-        app_state
-            .cpu_usage_history
-            .push(f64::from(aggregate_usage).clamp(0.0, 100.0));
-        while app_state.cpu_usage_history.len() > HISTORY_CAP {
-            app_state.cpu_usage_history.remove(0);
-        }
-    }
-
-    let gpu_map = build_gpu_map(&app_state.gpu_infos);
-    let page = procfs::page_size();
-    let mut procs: Vec<SystemProcess> = Vec::new();
-    let mut new_prev: HashMap<i32, u64> = HashMap::new();
-
-    let iter = all_processes().map_err(|e| {
-        // Keep the previous tray and CPU baselines so a transient /proc failure
-        // does not blank process monitoring or reset %CPU deltas.
-        NviError::General(format!("Process list unavailable: {e}"))
-    })?;
-
-    for p in iter.filter_map(|p| p.ok()) {
-        if let Ok(stat) = p.stat() {
-            let pid = stat.pid;
-            let ticks = stat.utime + stat.stime;
-            new_prev.insert(pid, ticks);
-
-            let cpu_usage = if total_delta > 0 {
-                match app_state.prev_proc_times.get(&pid) {
-                    Some(&prev) => {
-                        (ticks.saturating_sub(prev) as f64 / total_delta as f64
-                            * logical_cores as f64
-                            * 100.0) as f32
-                    }
-                    None => 0.0,
-                }
-            } else {
-                0.0
-            };
-
-            let (gpu_memory, gpu_index) = match gpu_map.get(&pid) {
-                Some(&(m, i)) => (Some(m), Some(i)),
-                None => (None, None),
-            };
-
-            procs.push(SystemProcess {
-                pid,
-                gpu_memory,
-                gpu_index,
-                username: String::new(),
-                command: stat.comm.clone(),
-                cpu_usage,
-                memory_usage: stat.rss * page,
-                state: stat.state,
-            });
-        }
-    }
-
-    app_state.prev_proc_times = new_prev;
-    app_state.process_scan = procs;
-    rebuild_process_tray(app_state);
-
-    Ok(())
-}
-
 /// Sort the last full scan by the active mode, keep top N, and enrich for display.
 pub fn rebuild_process_tray(app_state: &mut AppState) {
     let mut procs = app_state.process_scan.clone();
@@ -229,23 +105,6 @@ pub fn rebuild_process_tray(app_state: &mut AppState) {
     procs.truncate(TOP_N);
     enrich_processes(&mut procs, &mut app_state.uid_cache);
     app_state.processes = procs;
-}
-
-fn enrich_processes(procs: &mut [SystemProcess], uid_cache: &mut HashMap<u32, String>) {
-    for proc in procs.iter_mut() {
-        match Process::new(proc.pid) {
-            Ok(process) => {
-                if let Ok(uid) = process.uid() {
-                    proc.username = username_for(uid, uid_cache);
-                }
-                match process.cmdline() {
-                    Ok(cmd) if !cmd.join(" ").is_empty() => proc.command = cmd.join(" "),
-                    _ => proc.command = format!("[{}]", proc.command),
-                }
-            }
-            Err(_) => proc.command = format!("[{}]", proc.command),
-        }
-    }
 }
 
 /// Build an InfluxDB write for system-wide CPU/memory (used with `--cpu` + Influx).
@@ -262,20 +121,9 @@ pub fn system_metrics_write_query(cpu: &CpuStats) -> influxdb::WriteQuery {
         .add_field("mem_total", cpu.mem_total as i64)
         .add_field("swap_used", cpu.swap_used as i64)
         .add_field("swap_total", cpu.swap_total as i64)
+        // load_1 is 0.0 on Windows (no load average there); the schema is kept
+        // stable across platforms deliberately.
         .add_field("load_1", cpu.load_avg.0 as f64)
-}
-
-fn kernel_cpu_sample(t: &procfs::CpuTime) -> KernelCpuSample {
-    let idle = t.idle + t.iowait.unwrap_or(0);
-    let total = t.user
-        + t.nice
-        + t.system
-        + t.idle
-        + t.iowait.unwrap_or(0)
-        + t.irq.unwrap_or(0)
-        + t.softirq.unwrap_or(0)
-        + t.steal.unwrap_or(0);
-    KernelCpuSample { total, idle }
 }
 
 /// Percentage busy between two cumulative samples.
@@ -287,23 +135,6 @@ fn pct(prev: &KernelCpuSample, cur: &KernelCpuSample) -> f32 {
     } else {
         ((dt - di) as f64 / dt as f64 * 100.0) as f32
     }
-}
-
-fn read_cpu_model_freq() -> Option<(String, f64)> {
-    let info = procfs::CpuInfo::current().ok()?;
-    let model = info.model_name(0).unwrap_or("Unknown CPU").to_string();
-    let mut sum = 0.0;
-    let mut count = 0u32;
-    for i in 0..info.num_cores() {
-        if let Some(mhz) = info.get_field(i, "cpu MHz") {
-            if let Ok(v) = mhz.trim().parse::<f64>() {
-                sum += v;
-                count += 1;
-            }
-        }
-    }
-    let freq = if count > 0 { sum / count as f64 } else { 0.0 };
-    Some((model, freq))
 }
 
 /// Map PID -> (total_used_gpu_memory, gpu_index) from NVML-collected GPU process lists.
@@ -329,18 +160,411 @@ pub fn build_gpu_map(gpu_infos: &[GpuInfo]) -> HashMap<i32, (u64, usize)> {
         .collect()
 }
 
-fn username_for(uid: u32, cache: &mut HashMap<u32, String>) -> String {
-    if let Some(name) = cache.get(&uid) {
-        return name.clone();
+#[cfg(unix)]
+mod imp {
+    use super::{
+        CpuStats, HISTORY_CAP, KernelCpuSample, SystemProcess, build_gpu_map, pct,
+        rebuild_process_tray,
+    };
+    use crate::app_state::AppState;
+    use crate::error::NviError;
+    use nix::unistd::{Uid, User};
+    use procfs::prelude::*;
+    use procfs::process::{Process, all_processes};
+    use std::collections::HashMap;
+
+    /// Collect CPU stats, system memory, and the top-N process list.
+    pub fn collect_system_stats(app_state: &mut AppState) -> Result<(), NviError> {
+        let ks = procfs::KernelStats::current().map_err(|e| NviError::General(e.to_string()))?;
+        let cur_total = kernel_cpu_sample(&ks.total);
+        let total_delta = app_state
+            .prev_cpu_total
+            .as_ref()
+            .map(|p| cur_total.total.saturating_sub(p.total))
+            .unwrap_or(0);
+        let aggregate_usage = app_state
+            .prev_cpu_total
+            .as_ref()
+            .map(|p| pct(p, &cur_total))
+            .unwrap_or(0.0);
+        let logical_cores = ks.cpu_time.len();
+        let cur_per_core: Vec<KernelCpuSample> =
+            ks.cpu_time.iter().map(kernel_cpu_sample).collect();
+        let per_core_usage: Vec<f32> = cur_per_core
+            .iter()
+            .enumerate()
+            .map(|(i, cur)| {
+                app_state
+                    .prev_cpu_per_core
+                    .get(i)
+                    .map(|p| pct(p, cur))
+                    .unwrap_or(0.0)
+            })
+            .collect();
+
+        let (model, frequency_mhz) =
+            read_cpu_model_freq().unwrap_or_else(|| ("Unknown CPU".to_string(), 0.0));
+        let load_avg = procfs::LoadAverage::current()
+            .map(|l| (l.one, l.five, l.fifteen))
+            .unwrap_or((0.0, 0.0, 0.0));
+        let mem = procfs::Meminfo::current().map_err(|e| NviError::General(e.to_string()))?;
+        let mem_total = mem.mem_total;
+        let mem_used = mem_total.saturating_sub(mem.mem_available.unwrap_or(mem.mem_free));
+        let swap_total = mem.swap_total;
+        let swap_used = swap_total.saturating_sub(mem.swap_free);
+
+        // Commit CPU / memory panels even if the process scan fails below.
+        app_state.cpu_stats = CpuStats {
+            model,
+            logical_cores,
+            per_core_usage,
+            aggregate_usage,
+            frequency_mhz,
+            load_avg,
+            mem_total,
+            mem_used,
+            swap_total,
+            swap_used,
+        };
+        let had_baseline = app_state.prev_cpu_total.is_some();
+        app_state.prev_cpu_total = Some(cur_total);
+        app_state.prev_cpu_per_core = cur_per_core;
+
+        if had_baseline {
+            app_state
+                .cpu_usage_history
+                .push(f64::from(aggregate_usage).clamp(0.0, 100.0));
+            while app_state.cpu_usage_history.len() > HISTORY_CAP {
+                app_state.cpu_usage_history.remove(0);
+            }
+        }
+
+        let gpu_map = build_gpu_map(&app_state.gpu_infos);
+        let page = procfs::page_size();
+        let mut procs: Vec<SystemProcess> = Vec::new();
+        let mut new_prev: HashMap<i32, u64> = HashMap::new();
+
+        let iter = all_processes().map_err(|e| {
+            // Keep the previous tray and CPU baselines so a transient /proc failure
+            // does not blank process monitoring or reset %CPU deltas.
+            NviError::General(format!("Process list unavailable: {e}"))
+        })?;
+
+        for p in iter.filter_map(|p| p.ok()) {
+            if let Ok(stat) = p.stat() {
+                let pid = stat.pid;
+                let ticks = stat.utime + stat.stime;
+                new_prev.insert(pid, ticks);
+
+                let cpu_usage = if total_delta > 0 {
+                    match app_state.prev_proc_times.get(&pid) {
+                        Some(&prev) => {
+                            (ticks.saturating_sub(prev) as f64 / total_delta as f64
+                                * logical_cores as f64
+                                * 100.0) as f32
+                        }
+                        None => 0.0,
+                    }
+                } else {
+                    0.0
+                };
+
+                let (gpu_memory, gpu_index) = match gpu_map.get(&pid) {
+                    Some(&(m, i)) => (Some(m), Some(i)),
+                    None => (None, None),
+                };
+
+                procs.push(SystemProcess {
+                    pid,
+                    gpu_memory,
+                    gpu_index,
+                    username: String::new(),
+                    command: stat.comm.clone(),
+                    cpu_usage,
+                    memory_usage: stat.rss * page,
+                    state: stat.state,
+                });
+            }
+        }
+
+        app_state.prev_proc_times = new_prev;
+        app_state.process_scan = procs;
+        rebuild_process_tray(app_state);
+
+        Ok(())
     }
-    let name = User::from_uid(Uid::from_raw(uid))
-        .ok()
-        .flatten()
-        .map(|u| u.name)
-        .unwrap_or_else(|| uid.to_string());
-    cache.insert(uid, name.clone());
-    name
+
+    pub(super) fn enrich_processes(
+        procs: &mut [SystemProcess],
+        uid_cache: &mut HashMap<u32, String>,
+    ) {
+        for proc in procs.iter_mut() {
+            match Process::new(proc.pid) {
+                Ok(process) => {
+                    if let Ok(uid) = process.uid() {
+                        proc.username = username_for(uid, uid_cache);
+                    }
+                    match process.cmdline() {
+                        Ok(cmd) if !cmd.join(" ").is_empty() => proc.command = cmd.join(" "),
+                        _ => proc.command = format!("[{}]", proc.command),
+                    }
+                }
+                Err(_) => proc.command = format!("[{}]", proc.command),
+            }
+        }
+    }
+
+    fn read_cpu_model_freq() -> Option<(String, f64)> {
+        let info = procfs::CpuInfo::current().ok()?;
+        let model = info.model_name(0).unwrap_or("Unknown CPU").to_string();
+        let mut sum = 0.0;
+        let mut count = 0u32;
+        for i in 0..info.num_cores() {
+            if let Some(mhz) = info.get_field(i, "cpu MHz") {
+                if let Ok(v) = mhz.trim().parse::<f64>() {
+                    sum += v;
+                    count += 1;
+                }
+            }
+        }
+        let freq = if count > 0 { sum / count as f64 } else { 0.0 };
+        Some((model, freq))
+    }
+
+    fn kernel_cpu_sample(t: &procfs::CpuTime) -> KernelCpuSample {
+        let idle = t.idle + t.iowait.unwrap_or(0);
+        let total = t.user
+            + t.nice
+            + t.system
+            + t.idle
+            + t.iowait.unwrap_or(0)
+            + t.irq.unwrap_or(0)
+            + t.softirq.unwrap_or(0)
+            + t.steal.unwrap_or(0);
+        KernelCpuSample { total, idle }
+    }
+
+    fn username_for(uid: u32, cache: &mut HashMap<u32, String>) -> String {
+        if let Some(name) = cache.get(&uid) {
+            return name.clone();
+        }
+        let name = User::from_uid(Uid::from_raw(uid))
+            .ok()
+            .flatten()
+            .map(|u| u.name)
+            .unwrap_or_else(|| uid.to_string());
+        cache.insert(uid, name.clone());
+        name
+    }
 }
+
+#[cfg(windows)]
+mod imp {
+    use super::{
+        CpuStats, HISTORY_CAP, KernelCpuSample, SystemProcess, build_gpu_map, rebuild_process_tray,
+    };
+    use crate::app_state::AppState;
+    use crate::error::NviError;
+    use crate::utils::system::with_probe;
+    use std::collections::HashMap;
+    use sysinfo::{ProcessStatus, ProcessesToUpdate};
+
+    /// Collect CPU stats, system memory, and the top-N process list.
+    pub fn collect_system_stats(app_state: &mut AppState) -> Result<(), NviError> {
+        let gpu_map = build_gpu_map(&app_state.gpu_infos);
+        let had_baseline = app_state.prev_cpu_total.is_some();
+
+        let procs: Vec<SystemProcess> = with_probe(|probe| {
+            // One pass: CPU deltas, memory, and the full process table. sysinfo
+            // computes cpu_usage internally across refreshes, so the first tick
+            // after startup reads zero (mirrors the unix baseline gate below).
+            probe.system.refresh_cpu_usage();
+            probe.system.refresh_memory();
+            probe
+                .system
+                .refresh_processes(ProcessesToUpdate::All, false);
+            // Populate the user table once per session so `enrich_processes`
+            // (called via `rebuild_process_tray` below) can resolve usernames.
+            probe.ensure_users();
+
+            app_state.cpu_stats = cpu_stats_from_system(&probe.system);
+
+            let mut procs: Vec<SystemProcess> = Vec::new();
+            for (pid, process) in probe.system.processes() {
+                let pid_i32 = pid.as_u32() as i32;
+                let (gpu_memory, gpu_index) = match gpu_map.get(&pid_i32) {
+                    Some(&(m, i)) => (Some(m), Some(i)),
+                    None => (None, None),
+                };
+                // sysinfo's Process::cpu_usage is top-style (100 = one saturated
+                // core, can exceed 100% on multi-core), matching the unix
+                // convention; no scaling applied.
+                procs.push(SystemProcess {
+                    pid: pid_i32,
+                    gpu_memory,
+                    gpu_index,
+                    username: String::new(),
+                    command: process.name().to_string_lossy().into_owned(),
+                    cpu_usage: process.cpu_usage(),
+                    // sysinfo >= 0.30 returns RSS in bytes (no page-size multiply).
+                    memory_usage: process.memory(),
+                    state: status_char(process.status()),
+                });
+            }
+            procs
+        });
+
+        // History gate: skip the first (zero-baseline) tick so the graph does
+        // not start with an artificial 0%. `prev_cpu_total` is reused as the
+        // "have we collected before" sentinel — its tick fields aren't read on
+        // Windows, only `is_some()` matters here.
+        if had_baseline {
+            app_state
+                .cpu_usage_history
+                .push(f64::from(app_state.cpu_stats.aggregate_usage).clamp(0.0, 100.0));
+            while app_state.cpu_usage_history.len() > HISTORY_CAP {
+                app_state.cpu_usage_history.remove(0);
+            }
+        }
+        app_state.prev_cpu_total = Some(KernelCpuSample::default());
+        app_state.prev_cpu_per_core = Vec::new();
+
+        app_state.process_scan = procs;
+        rebuild_process_tray(app_state);
+
+        Ok(())
+    }
+
+    /// Map a refreshed sysinfo `System` onto the platform-neutral `CpuStats`
+    /// panel. Load average is a Unix concept, so it is hard-zeroed on Windows
+    /// (the UI hides the field rather than approximating it). Extracted from
+    /// `collect_system_stats` so the Windows stat-mapping is unit-testable
+    /// without driving the full process-scan + username-resolution pipeline,
+    /// which needs the live Windows LSA backend.
+    fn cpu_stats_from_system(system: &sysinfo::System) -> CpuStats {
+        let cpus = system.cpus();
+        let logical_cores = cpus.len();
+        let model = cpus
+            .first()
+            .map(|c| c.brand().to_string())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "Unknown CPU".to_string());
+        let per_core_usage: Vec<f32> = cpus.iter().map(|c| c.cpu_usage()).collect();
+        let aggregate_usage = system.global_cpu_usage();
+        let frequency_mhz = if cpus.is_empty() {
+            0.0
+        } else {
+            cpus.iter().map(|c| c.frequency() as f64).sum::<f64>() / cpus.len() as f64
+        };
+        CpuStats {
+            model,
+            logical_cores,
+            per_core_usage,
+            aggregate_usage,
+            frequency_mhz,
+            load_avg: (0.0, 0.0, 0.0),
+            mem_total: system.total_memory(),
+            mem_used: system.used_memory(),
+            swap_total: system.total_swap(),
+            swap_used: system.used_swap(),
+        }
+    }
+
+    pub(super) fn enrich_processes(
+        procs: &mut [SystemProcess],
+        uid_cache: &mut HashMap<u32, String>,
+    ) {
+        // sysinfo resolves username/cmdline from its own cached process table,
+        // so the unix uid_cache isn't needed here. The parameter is kept in the
+        // signature so `rebuild_process_tray` stays platform-neutral.
+        let _ = uid_cache;
+        with_probe(|probe| {
+            for proc_row in procs.iter_mut() {
+                let pid = sysinfo::Pid::from_u32(proc_row.pid as u32);
+                match probe.system.process(pid) {
+                    Some(process) => {
+                        let joined = process
+                            .cmd()
+                            .iter()
+                            .map(|s| s.to_string_lossy().into_owned())
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        if !joined.is_empty() {
+                            proc_row.command = joined;
+                        } else if proc_row.command.is_empty() {
+                            proc_row.command = format!("[{}]", proc_row.pid);
+                        }
+
+                        let username = process
+                            .user_id()
+                            .and_then(|uid| probe.users.get_user_by_id(uid))
+                            .map(|u| u.name().to_string())
+                            .unwrap_or_else(|| "?".to_string());
+                        proc_row.username = username;
+                    }
+                    None => {
+                        if proc_row.command.is_empty() {
+                            proc_row.command = format!("[{}]", proc_row.pid);
+                        }
+                        proc_row.username = "?".to_string();
+                    }
+                }
+            }
+        });
+    }
+
+    /// Map a sysinfo `ProcessStatus` to the single-char state column used by the
+    /// tray. Windows has no `/proc` state char, so we collapse to the closest
+    /// unix equivalent; anything unmapped becomes `'?'`.
+    fn status_char(status: ProcessStatus) -> char {
+        match status {
+            ProcessStatus::Run => 'R',
+            ProcessStatus::Sleep => 'S',
+            ProcessStatus::Stop => 'T',
+            ProcessStatus::Zombie => 'Z',
+            _ => '?',
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::status_char;
+        use sysinfo::ProcessStatus;
+
+        #[test]
+        fn test_status_char_mapping() {
+            assert_eq!(status_char(ProcessStatus::Run), 'R');
+            assert_eq!(status_char(ProcessStatus::Sleep), 'S');
+            assert_eq!(status_char(ProcessStatus::Stop), 'T');
+            assert_eq!(status_char(ProcessStatus::Zombie), 'Z');
+            // Everything else collapses to the unknown sentinel.
+            assert_eq!(status_char(ProcessStatus::Idle), '?');
+            assert_eq!(status_char(ProcessStatus::Dead), '?');
+            assert_eq!(status_char(ProcessStatus::Unknown(0)), '?');
+        }
+
+        #[test]
+        fn test_cpu_stats_windows_no_load_avg() {
+            // Drives the real sysinfo CPU/memory backend (the part of
+            // `collect_system_stats` that this assertion is about) without the
+            // full process-scan + username-resolution pipeline, which needs the
+            // live Windows LSA backend. Load average is a Unix concept and must
+            // be hard-zeroed on Windows; total memory must be non-zero on any
+            // real (or Wine-emulated) Windows host.
+            use super::cpu_stats_from_system;
+            use sysinfo::System;
+
+            let mut system = System::new();
+            system.refresh_cpu_usage();
+            system.refresh_memory();
+            let stats = cpu_stats_from_system(&system);
+            assert_eq!(stats.load_avg, (0.0, 0.0, 0.0));
+            assert!(stats.mem_total > 0);
+        }
+    }
+}
+
+pub use imp::*;
 
 #[cfg(test)]
 mod tests {

--- a/src/system_monitor.rs
+++ b/src/system_monitor.rs
@@ -127,6 +127,10 @@ pub fn system_metrics_write_query(cpu: &CpuStats) -> influxdb::WriteQuery {
 }
 
 /// Percentage busy between two cumulative samples.
+// Only the unix backend calls this from non-test code (the Windows backend
+// has no cumulative kernel counters to feed it); the platform-neutral tests
+// below exercise it on both platforms.
+#[cfg_attr(windows, allow(dead_code))]
 fn pct(prev: &KernelCpuSample, cur: &KernelCpuSample) -> f32 {
     let dt = cur.total.saturating_sub(prev.total);
     let di = cur.idle.saturating_sub(prev.idle).min(dt);

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -38,10 +38,7 @@ fn render_terminal_too_small(f: &mut Frame, area: Rect, min_w: u16, required_h: 
             area.width, area.height
         ),
         (true, false) => format!("Need at least {min_w} columns (now {})", area.width),
-        (false, true) => format!(
-            "Need at least {required_h} rows (now {})",
-            area.height
-        ),
+        (false, true) => format!("Need at least {required_h} rows (now {})", area.height),
         (false, false) => unreachable!(),
     };
     let message = format!("Terminal too small\n{size_hint}\n\nResize to continue");
@@ -362,8 +359,12 @@ pub fn render_process_list(f: &mut Frame, area: Rect, app_state: &AppState) {
             ];
 
             if index == app_state.selected_process {
-                Row::new(cells.into_iter().map(|text| Cell::from(text).style(selected_style)))
-                    .style(selected_style)
+                Row::new(
+                    cells
+                        .into_iter()
+                        .map(|text| Cell::from(text).style(selected_style)),
+                )
+                .style(selected_style)
             } else {
                 let [gpu, pid, gpu_mem, cpu_pct, mem, user, cmd] = cells;
                 Row::new(vec![
@@ -487,8 +488,12 @@ pub fn render_system_process_list(f: &mut Frame, area: Rect, app_state: &AppStat
             ];
 
             if index == app_state.selected_process {
-                Row::new(cells.into_iter().map(|text| Cell::from(text).style(selected_style)))
-                    .style(selected_style)
+                Row::new(
+                    cells
+                        .into_iter()
+                        .map(|text| Cell::from(text).style(selected_style)),
+                )
+                .style(selected_style)
             } else {
                 let [gpu, pid, gpu_mem, cpu, mem, user, state, cmd] = cells;
                 Row::new(vec![
@@ -545,7 +550,11 @@ pub fn render_system_process_list(f: &mut Frame, area: Rect, app_state: &AppStat
                 .add_modifier(Modifier::BOLD),
         ),
         Cell::from("User").style(Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
-        Cell::from("S").style(Style::default().fg(Color::Gray).add_modifier(Modifier::BOLD)),
+        Cell::from("S").style(
+            Style::default()
+                .fg(Color::Gray)
+                .add_modifier(Modifier::BOLD),
+        ),
         Cell::from("Command").style(Style::default().add_modifier(Modifier::BOLD)),
     ]))
     .column_spacing(1);

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -1,6 +1,6 @@
 use crate::app_state::AppState;
 use crate::gpu::info::GpuInfo;
-use crate::system_monitor::{meter_bar, meter_cell_width, CpuStats};
+use crate::system_monitor::{CpuStats, meter_bar, meter_cell_width};
 use crate::utils::format_memory_size;
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -113,7 +113,10 @@ pub fn render_help(f: &mut Frame, area: Rect, scroll: u16, cpu_monitoring: bool)
     let scroll = scroll.min(max_scroll);
 
     let title = if max_scroll > 0 {
-        format!(" Help  ·  ↑↓ scroll ({}/{})  ·  Esc/? close ", scroll, max_scroll)
+        format!(
+            " Help  ·  ↑↓ scroll ({}/{})  ·  Esc/? close ",
+            scroll, max_scroll
+        )
     } else {
         " Help  ·  Esc/? close ".to_string()
     };
@@ -295,7 +298,7 @@ pub fn render_cpu_info(f: &mut Frame, area: Rect, cpu: &CpuStats) {
         "Swap: none".to_string()
     };
 
-    let lines = vec![
+    let mut lines = vec![
         Line::from(Span::styled(
             model,
             Style::default()
@@ -306,13 +309,22 @@ pub fn render_cpu_info(f: &mut Frame, area: Rect, cpu: &CpuStats) {
             "Cores: {}   Freq: {:.0} MHz",
             cpu.logical_cores, cpu.frequency_mhz
         )),
-        Line::from(format!(
-            "Load:  {:.2}  {:.2}  {:.2}",
-            cpu.load_avg.0, cpu.load_avg.1, cpu.load_avg.2
-        )),
-        Line::from(Span::styled(mem_line, Style::default().fg(Color::Blue))),
-        Line::from(Span::styled(swap_line, Style::default().fg(Color::Cyan))),
     ];
+    // Load average is a Unix-only concept; sysinfo returns zeros on Windows, so
+    // hide the line there rather than display three meaningless "0.00" values.
+    #[cfg(unix)]
+    lines.push(Line::from(format!(
+        "Load:  {:.2}  {:.2}  {:.2}",
+        cpu.load_avg.0, cpu.load_avg.1, cpu.load_avg.2
+    )));
+    lines.push(Line::from(Span::styled(
+        mem_line,
+        Style::default().fg(Color::Blue),
+    )));
+    lines.push(Line::from(Span::styled(
+        swap_line,
+        Style::default().fg(Color::Cyan),
+    )));
     f.render_widget(Paragraph::new(lines), inner);
 }
 
@@ -400,11 +412,7 @@ fn render_cpu_graph(f: &mut Frame, area: Rect, app_state: &AppState) {
         .data(&data);
 
     let chart = Chart::new(vec![dataset])
-        .block(
-            Block::default()
-                .title("CPU History")
-                .borders(Borders::ALL),
-        )
+        .block(Block::default().title("CPU History").borders(Borders::ALL))
         .x_axis(
             Axis::default()
                 .style(Style::default().fg(Color::Gray))

--- a/src/ui/widgets.rs
+++ b/src/ui/widgets.rs
@@ -366,7 +366,7 @@ fn render_cpu_meters(f: &mut Frame, area: Rect, cpu: &CpuStats) {
     }
 
     let cols = (inner.width as usize / meter_cell_width()).max(1);
-    let rows_n = (cores + cols - 1) / cols;
+    let rows_n = cores.div_ceil(cols);
 
     let mut lines: Vec<Line> = Vec::with_capacity(rows_n);
     for r in 0..rows_n {

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -1,81 +1,263 @@
-use crate::error::NviError;
-use crate::gpu::GpuProcessInfo;
-use nix::sys::signal::{Signal, kill};
-use nix::unistd::Pid;
-use nix::unistd::{SysconfVar, sysconf};
-use nix::unistd::{Uid, User};
-use procfs::process::Process;
 use std::time::Instant;
 
 /// Prior `/proc/[pid]/stat` CPU tick sample for delta %CPU.
+///
+/// On Unix `total_ticks` is the cumulative `utime + stime` from `/proc`.
+/// On Windows there is no cumulative tick counter, so `total_ticks` stores a
+/// sysinfo-derived value instead (see the Windows backend for the convention).
+/// The struct's public contract — a `u64` carried between ticks with a timestamp —
+/// is unchanged, and callers (`gpu/info.rs`) treat it opaquely.
 #[derive(Clone, Copy, Debug)]
 pub struct CpuSample {
     pub total_ticks: u64,
     pub at: Instant,
 }
 
-pub fn get_process_info(
-    pid: u32,
-    used_gpu_memory: u64,
-    previous: Option<&CpuSample>,
-) -> Option<(GpuProcessInfo, CpuSample)> {
-    let process = Process::new(pid as i32).ok()?;
-    let uid = process.uid().ok()?;
-    let user = User::from_uid(Uid::from_raw(uid)).ok().flatten()?;
+#[cfg(unix)]
+mod imp {
+    use super::CpuSample;
+    use crate::error::NviError;
+    use crate::gpu::GpuProcessInfo;
+    use nix::sys::signal::{Signal, kill};
+    use nix::unistd::Pid;
+    use nix::unistd::{SysconfVar, sysconf};
+    use nix::unistd::{Uid, User};
+    use procfs::process::Process;
+    use std::time::Instant;
 
-    let command = process.cmdline().unwrap_or_default().join(" ");
+    pub fn get_process_info(
+        pid: u32,
+        used_gpu_memory: u64,
+        previous: Option<&CpuSample>,
+    ) -> Option<(GpuProcessInfo, CpuSample)> {
+        let process = Process::new(pid as i32).ok()?;
+        let uid = process.uid().ok()?;
+        let user = User::from_uid(Uid::from_raw(uid)).ok().flatten()?;
 
-    let stat = process.stat().ok()?;
-    let total_ticks = stat.utime + stat.stime;
-    let clock_ticks = get_clock_ticks_per_second() as f64;
-    let memory_usage = stat.rss * 4096;
+        let command = process.cmdline().unwrap_or_default().join(" ");
 
-    // Top-style %CPU: CPU seconds accrued / wall seconds since last sample × 100.
-    // Can exceed 100% on multi-core. Unavailable until a second sample exists.
-    let now = Instant::now();
-    let cpu_percent = previous.and_then(|prev| {
-        let dt = now.duration_since(prev.at).as_secs_f64();
-        if dt <= f64::EPSILON || total_ticks < prev.total_ticks {
-            return None;
+        let stat = process.stat().ok()?;
+        let total_ticks = stat.utime + stat.stime;
+        let clock_ticks = get_clock_ticks_per_second() as f64;
+        let memory_usage = stat.rss * 4096;
+
+        // Top-style %CPU: CPU seconds accrued / wall seconds since last sample × 100.
+        // Can exceed 100% on multi-core. Unavailable until a second sample exists.
+        let now = Instant::now();
+        let cpu_percent = previous.and_then(|prev| {
+            let dt = now.duration_since(prev.at).as_secs_f64();
+            if dt <= f64::EPSILON || total_ticks < prev.total_ticks {
+                return None;
+            }
+            let delta_secs = (total_ticks - prev.total_ticks) as f64 / clock_ticks;
+            Some((delta_secs / dt * 100.0) as f32)
+        });
+
+        let sample = CpuSample {
+            total_ticks,
+            at: now,
+        };
+
+        Some((
+            GpuProcessInfo {
+                pid,
+                used_gpu_memory,
+                username: user.name,
+                command,
+                cpu_percent,
+                memory_usage,
+            },
+            sample,
+        ))
+    }
+
+    pub fn kill_selected_process(pid: u32, command: &str) -> Result<(), NviError> {
+        match kill(Pid::from_raw(pid as i32), Signal::SIGTERM) {
+            Ok(_) => Ok(()),
+            Err(nix::Error::EPERM) => Err(NviError::Process(format!(
+                "Permission denied to terminate process {pid} ({command})"
+            ))),
+            Err(e) => Err(NviError::Process(format!(
+                "Failed to terminate process {pid} ({command}): {e}"
+            ))),
         }
-        let delta_secs = (total_ticks - prev.total_ticks) as f64 / clock_ticks;
-        Some((delta_secs / dt * 100.0) as f32)
-    });
+    }
 
-    let sample = CpuSample {
-        total_ticks,
-        at: now,
-    };
-
-    Some((
-        GpuProcessInfo {
-            pid,
-            used_gpu_memory,
-            username: user.name,
-            command,
-            cpu_percent,
-            memory_usage,
-        },
-        sample,
-    ))
-}
-
-pub fn kill_selected_process(pid: u32, command: &str) -> Result<(), NviError> {
-    match kill(Pid::from_raw(pid as i32), Signal::SIGTERM) {
-        Ok(_) => Ok(()),
-        Err(nix::Error::EPERM) => Err(NviError::Process(format!(
-            "Permission denied to terminate process {pid} ({command})"
-        ))),
-        Err(e) => Err(NviError::Process(format!(
-            "Failed to terminate process {pid} ({command}): {e}"
-        ))),
+    pub fn get_clock_ticks_per_second() -> u64 {
+        sysconf(SysconfVar::CLK_TCK)
+            .ok()
+            .flatten()
+            .map(|ticks| ticks as u64)
+            .unwrap_or(100)
     }
 }
 
-pub fn get_clock_ticks_per_second() -> u64 {
-    sysconf(SysconfVar::CLK_TCK)
-        .ok()
-        .flatten()
-        .map(|ticks| ticks as u64)
-        .unwrap_or(100)
+#[cfg(windows)]
+mod imp {
+    use super::CpuSample;
+    use crate::error::NviError;
+    use crate::gpu::GpuProcessInfo;
+    use std::cell::RefCell;
+    use sysinfo::{Pid, ProcessesToUpdate, Signal, System, Users};
+
+    /// Shared sysinfo probe: `System` for process/CPU/memory data, `Users` for
+    /// username lookup. Held in a `thread_local!` so the public signatures of
+    /// `get_process_info` / `collect_system_stats` stay unchanged (the whole app
+    /// is single-threaded for these calls). Constructing a `System::new_all()`
+    /// per tick would re-enumerate every process per GPU process per refresh —
+    /// a full scan ~13×/s on a 4-GPU-proc box at `--watch 300`, which would sink
+    /// the "0.28% CPU" headline number. The probe refreshes only what is needed.
+    pub struct PlatformProbe {
+        // `pub(crate)`: the `--cpu` backend in `system_monitor::imp` drives the
+        // same shared `System`/`Users` directly rather than through wrappers, so
+        // one refresh covers both the GPU-process and system-stat paths.
+        pub(crate) system: System,
+        pub(crate) users: Users,
+        // Whether `users` has been populated yet. `Users::new()` is empty by
+        // design (see `ensure_users`); the LSA-backed enumeration runs lazily on
+        // the first real production lookup, not at construction. This keeps the
+        // pure-logic unit tests (which drive an empty `System`) off the live
+        // Windows backend entirely.
+        users_refreshed: bool,
+    }
+
+    impl PlatformProbe {
+        fn new() -> Self {
+            Self {
+                system: System::new(),
+                users: Users::new(),
+                users_refreshed: false,
+            }
+        }
+
+        /// Populate the user table once per probe lifetime. Logged-in users
+        /// barely change during a session, and `Users::refresh()` is the one
+        /// sysinfo call that touches the Windows LSA (`LsaEnumerateLogonSessions`)
+        /// — deferring it (instead of running it at construction, as
+        /// `Users::new_with_refreshed_list` would) keeps username lookup
+        /// pay-per-use and the unit tests off the live system backend.
+        pub(crate) fn ensure_users(&mut self) {
+            if !self.users_refreshed {
+                self.users.refresh();
+                self.users_refreshed = true;
+            }
+        }
+    }
+
+    thread_local! {
+        static PROBE: RefCell<PlatformProbe> = RefCell::new(PlatformProbe::new());
+    }
+
+    /// Run `f` against the thread-local probe. Exposed for `system_monitor`'s
+    /// `--cpu` backend, which needs the same shared `System` instance.
+    pub(crate) fn with_probe<R>(f: impl FnOnce(&mut PlatformProbe) -> R) -> R {
+        PROBE.with_borrow_mut(f)
+    }
+
+    pub fn get_process_info(
+        pid: u32,
+        used_gpu_memory: u64,
+        previous: Option<&CpuSample>,
+    ) -> Option<(GpuProcessInfo, CpuSample)> {
+        with_probe(|probe| {
+            let sid = Pid::from_u32(pid);
+            // Refresh only this PID: avoids a full process enumeration per GPU
+            // process per tick (the perf killer called out in the spec).
+            probe
+                .system
+                .refresh_processes(ProcessesToUpdate::Some(&[sid]), false);
+            // Populate the user table once so username lookup below can resolve.
+            probe.ensure_users();
+            let process = probe.system.process(sid)?;
+
+            let username = process
+                .user_id()
+                .and_then(|uid| probe.users.get_user_by_id(uid))
+                .map(|u| u.name().to_string())
+                .unwrap_or_else(|| "?".to_string());
+
+            let command = {
+                let joined = process
+                    .cmd()
+                    .iter()
+                    .map(|s| s.to_string_lossy().into_owned())
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                if !joined.is_empty() {
+                    joined
+                } else {
+                    let name = process.name().to_string_lossy().into_owned();
+                    if name.is_empty() {
+                        format!("[{pid}]")
+                    } else {
+                        name
+                    }
+                }
+            };
+
+            // sysinfo >= 0.30 returns RSS in bytes (no page-size multiply needed).
+            let memory_usage = process.memory();
+
+            // sysinfo's `cpu_usage()` is top-style: 100 = one saturated core,
+            // can exceed 100% on multi-core — same convention as the unix /proc
+            // calculation, so no normalisation is applied. It needs two refreshes
+            // to be meaningful; gate on `previous` so the first sample shows "—"
+            // (None) exactly like the unix backend's first-tick behaviour.
+            let raw = process.cpu_usage();
+            let cpu_percent = previous.map(|_| raw);
+
+            // `total_ticks` has no cumulative-tick meaning on Windows; stash the
+            // scaled percentage so the struct contract (`u64` + timestamp) holds.
+            // The value is opaque to callers and is not used for delta math here
+            // because sysinfo already computes the delta internally.
+            let sample = CpuSample {
+                total_ticks: (raw as f64 * 100.0) as u64,
+                at: std::time::Instant::now(),
+            };
+
+            Some((
+                GpuProcessInfo {
+                    pid,
+                    used_gpu_memory,
+                    username,
+                    command,
+                    cpu_percent,
+                    memory_usage,
+                },
+                sample,
+            ))
+        })
+    }
+
+    pub fn kill_selected_process(pid: u32, command: &str) -> Result<(), NviError> {
+        with_probe(|probe| {
+            let sid = Pid::from_u32(pid);
+            probe
+                .system
+                .refresh_processes(ProcessesToUpdate::Some(&[sid]), false);
+            let Some(process) = probe.system.process(sid) else {
+                return Err(NviError::Process(format!(
+                    "Failed to terminate process {pid} ({command}): no such process"
+                )));
+            };
+            // Try a graceful terminate first; sysinfo returns `None` when the
+            // signal is unsupported on this platform (Windows supports few), in
+            // which case fall back to the always-available force-kill. sysinfo
+            // exposes only a `bool`, so — unlike the unix EPERM branch — we cannot
+            // distinguish permission denial from other failures; a failed send is
+            // reported with the generic message used by the unix non-EPERM path.
+            let sent = process
+                .kill_with(Signal::Term)
+                .unwrap_or_else(|| process.kill());
+            if sent {
+                Ok(())
+            } else {
+                Err(NviError::Process(format!(
+                    "Failed to terminate process {pid} ({command})"
+                )))
+            }
+        })
+    }
 }
+
+pub use imp::*;

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -102,7 +102,7 @@ mod imp {
     use crate::error::NviError;
     use crate::gpu::GpuProcessInfo;
     use std::cell::RefCell;
-    use sysinfo::{Pid, ProcessesToUpdate, Signal, System, Users};
+    use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, Signal, System, UpdateKind, Users};
 
     /// Shared sysinfo probe: `System` for process/CPU/memory data, `Users` for
     /// username lookup. Held in a `thread_local!` so the public signatures of
@@ -158,6 +158,22 @@ mod imp {
         PROBE.with_borrow_mut(f)
     }
 
+    /// Refresh kind shared by the GPU-process and `--cpu` backends. The
+    /// default `refresh_processes` kind omits `cmd` and `user`, and on
+    /// Windows `Process::user_id()` is only populated when the refresh kind
+    /// asks for it — without this the command and username columns stay
+    /// empty. `OnlyIfNotSet` matches `ProcessRefreshKind::everything()`'s
+    /// convention: fetched once per process lifetime rather than re-read
+    /// every tick. CPU and memory feed the %CPU and Mem columns; disk usage
+    /// and exe are not read anywhere.
+    pub(crate) fn process_refresh_kind() -> ProcessRefreshKind {
+        ProcessRefreshKind::nothing()
+            .with_cpu()
+            .with_memory()
+            .with_cmd(UpdateKind::OnlyIfNotSet)
+            .with_user(UpdateKind::OnlyIfNotSet)
+    }
+
     pub fn get_process_info(
         pid: u32,
         used_gpu_memory: u64,
@@ -167,9 +183,11 @@ mod imp {
             let sid = Pid::from_u32(pid);
             // Refresh only this PID: avoids a full process enumeration per GPU
             // process per tick (the perf killer called out in the spec).
-            probe
-                .system
-                .refresh_processes(ProcessesToUpdate::Some(&[sid]), false);
+            probe.system.refresh_processes_specifics(
+                ProcessesToUpdate::Some(&[sid]),
+                false,
+                process_refresh_kind(),
+            );
             // Populate the user table once so username lookup below can resolve.
             probe.ensure_users();
             let process = probe.system.process(sid)?;

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -8,6 +8,10 @@ use std::time::Instant;
 /// The struct's public contract — a `u64` carried between ticks with a timestamp —
 /// is unchanged, and callers (`gpu/info.rs`) treat it opaquely.
 #[derive(Clone, Copy, Debug)]
+// Only the unix backend reads the fields back for delta math; the Windows
+// backend constructs samples to honour the shared contract but reads nothing
+// from them (sysinfo computes the delta internally).
+#[cfg_attr(windows, allow(dead_code))]
 pub struct CpuSample {
     pub total_ticks: u64,
     pub at: Instant,

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -102,7 +102,7 @@ mod imp {
     use crate::error::NviError;
     use crate::gpu::GpuProcessInfo;
     use std::cell::RefCell;
-    use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, Signal, System, UpdateKind, Users};
+    use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind, Users};
 
     /// Shared sysinfo probe: `System` for process/CPU/memory data, `Users` for
     /// username lookup. Held in a `thread_local!` so the public signatures of
@@ -183,9 +183,14 @@ mod imp {
             let sid = Pid::from_u32(pid);
             // Refresh only this PID: avoids a full process enumeration per GPU
             // process per tick (the perf killer called out in the spec).
+            // remove_dead_processes = true: a pid that died since the last
+            // NVML query is dropped here, so the row disappears silently
+            // instead of showing frozen numbers, and a reused pid gets a
+            // fresh entry (with fresh cmd/user reads) rather than the dead
+            // predecessor's.
             probe.system.refresh_processes_specifics(
                 ProcessesToUpdate::Some(&[sid]),
-                false,
+                true,
                 process_refresh_kind(),
             );
             // Populate the user table once so username lookup below can resolve.
@@ -252,33 +257,34 @@ mod imp {
     }
 
     pub fn kill_selected_process(pid: u32, command: &str) -> Result<(), NviError> {
-        with_probe(|probe| {
-            let sid = Pid::from_u32(pid);
-            probe
-                .system
-                .refresh_processes(ProcessesToUpdate::Some(&[sid]), false);
-            let Some(process) = probe.system.process(sid) else {
-                return Err(NviError::Process(format!(
-                    "Failed to terminate process {pid} ({command}): no such process"
-                )));
-            };
-            // Try a graceful terminate first; sysinfo returns `None` when the
-            // signal is unsupported on this platform (Windows supports few), in
-            // which case fall back to the always-available force-kill. sysinfo
-            // exposes only a `bool`, so — unlike the unix EPERM branch — we cannot
-            // distinguish permission denial from other failures; a failed send is
-            // reported with the generic message used by the unix non-EPERM path.
-            let sent = process
-                .kill_with(Signal::Term)
-                .unwrap_or_else(|| process.kill());
-            if sent {
-                Ok(())
-            } else {
-                Err(NviError::Process(format!(
-                    "Failed to terminate process {pid} ({command})"
-                )))
-            }
-        })
+        // sysinfo's Process::kill() shells out to `taskkill /PID <pid> /F` as
+        // well but returns only a bool, which cannot distinguish permission
+        // denial from other failures. Calling taskkill directly keeps the
+        // unix branch's message set via its exit codes: 0 success, 1 access
+        // denied, 128 no such process. stderr text is deliberately not
+        // matched — it is localized on non-English Windows, the exit codes
+        // are not. Output is captured (not inherited) so taskkill's own
+        // ERROR/SUCCESS lines cannot corrupt the TUI.
+        let output = std::process::Command::new("taskkill")
+            .args(["/PID", &pid.to_string(), "/F"])
+            .output()
+            .map_err(|e| {
+                NviError::Process(format!(
+                    "Failed to terminate process {pid} ({command}): {e}"
+                ))
+            })?;
+        match output.status.code() {
+            Some(0) => Ok(()),
+            Some(1) => Err(NviError::Process(format!(
+                "Permission denied to terminate process {pid} ({command})"
+            ))),
+            Some(128) => Err(NviError::Process(format!(
+                "Failed to terminate process {pid} ({command}): no such process"
+            ))),
+            _ => Err(NviError::Process(format!(
+                "Failed to terminate process {pid} ({command})"
+            ))),
+        }
     }
 }
 


### PR DESCRIPTION
`cargo install nviwatch` currently fails to build on Windows: `procfs` supports only Linux/Android and `nix` is POSIX-only.

## Approach

Purely additive platform split — the Linux code path is unchanged:

- `procfs`/`nix` moved to `[target.'cfg(unix)'.dependencies]`; the existing implementations are wrapped in `#[cfg(unix)] mod imp` with bodies unchanged (the only edits are rustfmt reflows at spots where master itself is not fmt-clean under current rustfmt)
- a new `#[cfg(windows)]` backend backed by `sysinfo` with the same public API (`get_process_info`, `kill_selected_process`, `collect_system_stats`), so the call sites in `gpu/info.rs` and `main.rs` are untouched
- `sysinfo` lives under `[target.'cfg(windows)'.dependencies]` — it does not enter the Linux dependency graph at all (`cargo tree | grep sysinfo` is empty on Linux)

## Windows behavior notes

- Process %CPU uses the same top-style convention as the `/proc` path (100 = one saturated core, can exceed 100% on multi-core); no re-normalisation needed
- Load average has no Windows equivalent: the value is `(0, 0, 0)` and the UI line is hidden via `#[cfg(unix)]` rather than showing fake zeros; the InfluxDB `load_1` field stays in the schema with `0.0` so it does not diverge per platform
- `x` kill shells out to `taskkill` and classifies by exit code (0 success / 1 access denied / 128 no such process — locale-independent), so "Permission denied to terminate process N (cmd)" matches the unix EPERM branch
- The first refresh tick shows `—` / 0.0 for CPU just like the unix backend's first sample
- One shared `sysinfo::System` instance (thread-local probe) refreshed per-tick only for the pids it needs — no full `System::new_all()` per process per tick

## Testing

Validated on real Windows 11 hardware (RTX 1000 Ada, driver 596.36):

- `cargo build --release` — no procfs/nix in the dependency graph on Windows
- `cargo test` — 38/38; all platform-neutral tests run on both platforms, plus two new Windows-only tests (status-char mapping, cpu-stats without load average)
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean on Windows
- Runtime: GPU panel (name/temp/utilization/memory/power/clock), process list with resolved usernames and full command lines, `--cpu` panel (per-core meters, frequency, memory/swap), kill on an owned process and on a protected one (clean error, no panic), mode toggles, terminal restore on quit
- Linux: build/test/clippy/fmt still clean

## CI

Adds a separate `build-windows` job (`windows-latest`, uploads `nviwatch.exe` as a release asset). The existing Linux job is untouched.
