### PR TITLE
fix(cpu): keep process CPU% in 0-100

### DIFF
--- a/src/system_monitor.rs
+++ b/src/system_monitor.rs
@@ -3,6 +3,7 @@
 use crate::app_state::AppState;
 use crate::error::NviError;
 use crate::gpu::info::GpuInfo;
+use crate::utils::system::instant_process_cpu_pct_from_system;
 use nix::unistd::{Uid, User};
 use procfs::prelude::*;
 use procfs::process::{all_processes, Process};
@@ -184,17 +185,11 @@ pub fn collect_system_stats(app_state: &mut AppState) -> Result<(), NviError> {
             let ticks = stat.utime + stat.stime;
             new_prev.insert(pid, ticks);
 
-            let cpu_usage = if total_delta > 0 {
-                match app_state.prev_proc_times.get(&pid) {
-                    Some(&prev) => {
-                        (ticks.saturating_sub(prev) as f64 / total_delta as f64
-                            * logical_cores as f64
-                            * 100.0) as f32
-                    }
-                    None => 0.0,
+            let cpu_usage = match app_state.prev_proc_times.get(&pid) {
+                Some(&prev) => {
+                    instant_process_cpu_pct_from_system(ticks.saturating_sub(prev), total_delta)
                 }
-            } else {
-                0.0
+                None => 0.0,
             };
 
             let (gpu_memory, gpu_index) = match gpu_map.get(&pid) {
@@ -391,6 +386,17 @@ mod tests {
             idle: 200,
         };
         assert_eq!(pct(&prev, &cur), 50.0);
+    }
+
+    #[test]
+    fn test_process_cpu_seven_of_eight_cores_is_not_700() {
+        // Old main formula: proc_delta / system_delta * ncpus * 100 = 700.
+        let pct = instant_process_cpu_pct_from_system(700, 800);
+        assert!(
+            (pct - 87.5).abs() < 0.01,
+            "expected 87.5% of machine, got {pct}"
+        );
+        assert!(pct <= 100.0);
     }
 
     #[test]

--- a/src/utils/system.rs
+++ b/src/utils/system.rs
@@ -1,8 +1,8 @@
 use crate::error::NviError;
 use crate::gpu::GpuProcessInfo;
-use nix::sys::signal::{Signal, kill};
+use nix::sys::signal::{kill, Signal};
 use nix::unistd::Pid;
-use nix::unistd::{SysconfVar, sysconf};
+use nix::unistd::{sysconf, SysconfVar};
 use nix::unistd::{Uid, User};
 use procfs::process::Process;
 use std::time::Instant;
@@ -30,16 +30,17 @@ pub fn get_process_info(
     let clock_ticks = get_clock_ticks_per_second() as f64;
     let memory_usage = stat.rss * 4096;
 
-    // Top-style %CPU: CPU seconds accrued / wall seconds since last sample × 100.
-    // Can exceed 100% on multi-core. Unavailable until a second sample exists.
+    // Instant % of total machine CPU (0–100). Unavailable until a second sample.
+    // Top-style (cpu_secs/wall_secs*100) is unbounded and hits 700% on 7 busy
+    // cores — that is the main-branch bug this replaces.
     let now = Instant::now();
+    let ncpus = online_cpus();
     let cpu_percent = previous.and_then(|prev| {
-        let dt = now.duration_since(prev.at).as_secs_f64();
-        if dt <= f64::EPSILON || total_ticks < prev.total_ticks {
+        if total_ticks < prev.total_ticks {
             return None;
         }
-        let delta_secs = (total_ticks - prev.total_ticks) as f64 / clock_ticks;
-        Some((delta_secs / dt * 100.0) as f32)
+        let dt = now.duration_since(prev.at).as_secs_f64();
+        instant_process_cpu_pct(total_ticks - prev.total_ticks, clock_ticks, dt, ncpus)
     });
 
     let sample = CpuSample {
@@ -78,4 +79,96 @@ pub fn get_clock_ticks_per_second() -> u64 {
         .flatten()
         .map(|ticks| ticks as u64)
         .unwrap_or(100)
+}
+
+pub fn online_cpus() -> u32 {
+    sysconf(SysconfVar::_NPROCESSORS_ONLN)
+        .ok()
+        .flatten()
+        .map(|n| n as u32)
+        .filter(|&n| n > 0)
+        .unwrap_or(1)
+}
+
+/// Instant process CPU as a percent of total machine capacity (0–100).
+///
+/// `delta_ticks` is utime+stime accrued since the last sample. `dt_secs` is
+/// wall time between samples. `ncpus` is online logical CPUs.
+///
+/// htop-style %CPU omits `/ ncpus` and reports 800% on an 8-core box. A
+/// `CPU%` column must not do that.
+pub fn instant_process_cpu_pct(
+    delta_ticks: u64,
+    clock_ticks: f64,
+    dt_secs: f64,
+    ncpus: u32,
+) -> Option<f32> {
+    if dt_secs <= f64::EPSILON || clock_ticks <= 0.0 || ncpus == 0 {
+        return None;
+    }
+    let cpu_secs = delta_ticks as f64 / clock_ticks;
+    let pct = cpu_secs / dt_secs / f64::from(ncpus) * 100.0;
+    Some(pct.clamp(0.0, 100.0) as f32)
+}
+
+/// Same metric from two tick counts in the same unit (process vs `/proc/stat`
+/// aggregate `cpu` line). Do not multiply by core count — `system_delta`
+/// already spans every CPU.
+pub fn instant_process_cpu_pct_from_system(proc_delta: u64, system_delta: u64) -> f32 {
+    if system_delta == 0 {
+        0.0
+    } else {
+        (proc_delta as f64 / system_delta as f64 * 100.0).clamp(0.0, 100.0) as f32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // 7 cores busy for 1s on an 8-core box @ 100 Hz.
+    // Top-style (main today) reports 700%. Column is CPU% of the machine.
+    const PROC_TICKS: u64 = 700;
+    const CLOCK: f64 = 100.0;
+    const DT: f64 = 1.0;
+    const NCPUS: u32 = 8;
+    const SYSTEM_TICKS: u64 = 800;
+
+    #[test]
+    fn seven_of_eight_cores_is_87_5_not_700() {
+        let pct = instant_process_cpu_pct(PROC_TICKS, CLOCK, DT, NCPUS).unwrap();
+        assert!(
+            (pct - 87.5).abs() < 0.01,
+            "expected 87.5% of machine, got {pct} (top-style would be 700)"
+        );
+        assert!(pct <= 100.0, "CPU% column must never exceed 100, got {pct}");
+    }
+
+    #[test]
+    fn system_delta_path_matches_wall_clock_path() {
+        let wall = instant_process_cpu_pct(PROC_TICKS, CLOCK, DT, NCPUS).unwrap();
+        let sys = instant_process_cpu_pct_from_system(PROC_TICKS, SYSTEM_TICKS);
+        assert!((wall - sys).abs() < 0.01, "wall={wall} system={sys}");
+    }
+
+    #[test]
+    fn fully_busy_machine_is_100_not_800() {
+        let pct = instant_process_cpu_pct(800, CLOCK, DT, NCPUS).unwrap();
+        assert!((pct - 100.0).abs() < 0.01, "got {pct}");
+        let sys = instant_process_cpu_pct_from_system(800, 800);
+        assert!((sys - 100.0).abs() < 0.01, "got {sys}");
+    }
+
+    #[test]
+    fn sampling_skew_clamps_to_100() {
+        // Process ticks can briefly exceed the /proc/stat aggregate window.
+        let pct = instant_process_cpu_pct_from_system(900, 800);
+        assert_eq!(pct, 100.0);
+    }
+
+    #[test]
+    fn no_elapsed_time_is_unavailable() {
+        assert_eq!(instant_process_cpu_pct(700, CLOCK, 0.0, NCPUS), None);
+        assert_eq!(instant_process_cpu_pct_from_system(700, 0), 0.0);
+    }
 }


### PR DESCRIPTION
Process CPU% was top-style (`cpu_secs / wall * 100`), so a 7-core workload shows 700% on an 8-core box. The `--cpu` tray hit the same scale via `* logical_cores`.

CPU% is now share of total machine capacity, clamped 0-100.

## Test plan

- [x] `cargo test` (42 passed)
- [x] Launch under compile load; column stays <= 100 (was 200%+)